### PR TITLE
feat(package): export the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "author": {
     "name": "Cenk Kilic",


### PR DESCRIPTION
TL;DR: Allows tooling to perform ad-hoc dependency analysis using require.resolve.

Would you be open to exporting the `package.json`.  We have a bunch of tooling that does dependency graph analysis of our packages and there currently isn't a workaround for [non-ESM packages](https://github.com/nodejs/node/issues/33460#issuecomment-630452758).

