### PR TITLE
Update renderer-default-persistent.ts

### DIFF
--- a/examples/docs/task/output/renderer-default-persistent.ts
+++ b/examples/docs/task/output/renderer-default-persistent.ts
@@ -7,7 +7,7 @@ const tasks = new Listr(
       task: async (ctx, task): Promise<void> => {
         task.output = 'I will push an output. [0]'
       },
-      rendererOptions: { persistentOutput: true }
+      options: { persistentOutput: true }
     }
   ],
   { concurrent: false }


### PR DESCRIPTION
Not working with "rendererOptions" key, but works with "options". Probably, the docs is outdated a litle bit.