### PR TITLE
Add output clearing to default renderer

### DIFF
--- a/examples/task-clear-output.example.ts
+++ b/examples/task-clear-output.example.ts
@@ -1,0 +1,48 @@
+import { delay, Listr } from 'listr2'
+
+const tasks = new Listr(
+  [
+    {
+      title: 'This will clear its output.',
+      task: async (_, task): Promise<void> => {
+        task.output = 'I will push an output. [0]'
+
+        await delay(1000)
+
+        task.output = 'I will push an output. [1]'
+
+        await delay(1000)
+
+        task.output = 'I will push an output. [2]'
+
+        await delay(1000)
+
+        task.output = ''
+      },
+      rendererOptions: { persistentOutput: true, outputBar: Infinity }
+    },
+    {
+      title: 'This will not clear its output.',
+      task: async (_, task): Promise<void> => {
+        task.output = 'I will push an output. [0]'
+
+        await delay(1000)
+
+        task.output = 'I will push an output. [1]'
+
+        await delay(1000)
+
+        task.output = 'I will push an output. [2]'
+      },
+      rendererOptions: { persistentOutput: true, outputBar: Infinity }
+    }
+  ],
+  {
+    rendererOptions: {
+      collapse: false,
+      removeEmptyLines: false
+    }
+  }
+)
+
+await tasks.run()

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -517,6 +517,12 @@ export class DefaultRenderer implements ListrRenderer {
       this.buffer.output.set(task.id, new ProcessOutputBuffer({ limit: typeof rendererTaskOptions.outputBar === 'number' ? rendererTaskOptions.outputBar : 1 }))
 
       task.on(ListrTaskEventType.OUTPUT, (output) => {
+        if (output === '') {
+          this.buffer.output.get(task.id).reset()
+
+          return
+        }
+
         this.buffer.output.get(task.id).write(output)
       })
 

--- a/packages/listr2/tests/renderer/default/output.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/default/output.e2e-spec.ts
@@ -116,6 +116,32 @@ describe('default renderer: output', () => {
     expectProcessOutputToMatchSnapshot(output, 'qmiOeXTUyStaFeRgDYVlGoPJMVDbRRuC')
   })
 
+  // it('should clear output from output bar', async () => {
+  //   await new Listr(
+  //     [
+  //       {
+  //         title: 'This task will execute.',
+  //         task: async (_, task): Promise<void> => {
+  //           task.output = 'I will push an output. [0]'
+
+  //           task.output = 'I will push an output. [1]'
+
+  //           task.output = 'I will push an output. [2]'
+
+  //           task.output = ''
+  //         },
+  //         rendererOptions: { outputBar: Infinity, persistentOutput: true }
+  //       }
+  //     ],
+  //     {
+  //       concurrent: false,
+  //       rendererOptions: { lazy: true }
+  //     }
+  //   ).run()
+
+  //   expectProcessOutputToMatchSnapshot(output)
+  // })
+
   // ojurBbWZEPenKVeoFcKksBeMbaYWmbGO
   it('should output to nowhere since outputBar and bottomBar is false', async () => {
     await new Listr(


### PR DESCRIPTION
Closes #703.

I've only added it when using the default renderer with the output bar. Currently, setting `task.output` to an empty string clears the output:

```js
task.output = ''
```

I've added an example as well. I'm not sure how to set up the snapshot tests with an ID.

Should I add output clearing elsewhere? (e.g. with another renderer or with the bottom bar, etc)