### PR TITLE
Docs: remove file prefix when importing in markdown

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -37,6 +37,6 @@ You can find the related examples [here](https://github.com/listr2/listr2/tree/m
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererOptions.md{156-186} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{156-186} -->
 
 :::

--- a/docs/listr/context.md
+++ b/docs/listr/context.md
@@ -19,7 +19,7 @@ While running a `listr2` task list, a self-contained variable is shared across t
 
 A context is an object that is shared across the task list. Even though external variables can be used to do the same operation, context gives a self-contained way to process internal tasks.
 
-Context can be anything that satisfies the type [ListrContext](/api/types/listr2.ListrContext.html), which is by default of type `any`, but it is advised to be an object, due to the intention of using it as a mutable structure that goes through the task.
+Context can be anything that satisfies the type [ListrContext](/api/listr2/type-aliases/ListrContext.html), which is by default of type `any`, but it is advised to be an object, due to the intention of using it as a mutable structure that goes through the task.
 
 Context type can be injected as a type parameter to Listr class to limit what is being used as the context throughout the task and ensure type safety.
 

--- a/docs/listr/listr.md
+++ b/docs/listr/listr.md
@@ -10,13 +10,13 @@ category:
 
 # {{ $frontmatter.title }}
 
-`listr2` is a stateful task list, therefore it is based on classes. To create a new task list, you must create an instance of [Listr](/api/listr2/classes/class..Listr.html) first.
+`listr2` is a stateful task list, therefore it is based on classes. To create a new task list, you must create an instance of [Listr](/api/listr2/classes/Listr.html) first.
 
 <!-- more -->
 
 ## Generate New Class
 
-Import and create a new task list from the prototype. It will return the created [Listr](/api/listr2/classes/class..Listr.html) class.
+Import and create a new task list from the prototype. It will return the created [Listr](/api/listr2/classes/Listr.html) class.
 
 <<< @../../examples/docs/listr/new-listr/creating-a-new-instance.ts#create{1,7}
 

--- a/docs/listr/manager.md
+++ b/docs/listr/manager.md
@@ -10,7 +10,7 @@ category:
 
 # {{ $frontmatter.title }}
 
-[Manager](/api/listr2/classes/class._manager.Manager.html) is a great way to create a custom-tailored _Listr_ class once and then utilize it more than once.
+[Manager](/api/@listr2/manager/classes/Manager.html) is a great way to create a custom-tailored _Listr_ class once and then utilize it more than once.
 
 <!-- more -->
 

--- a/docs/renderer/custom.md
+++ b/docs/renderer/custom.md
@@ -34,7 +34,7 @@ Take a look at _DefaultRenderer_ since it is implemented this way.
 
 ## Utilizing the Events
 
-_Listr_ and its _Task_ fires many events to indicate the task status. _Task_ depending on what is currently done will fire [ListrTaskState](/api/listr2/enumerations/enumeration.ListrTaskState.html) and [ListrTaskEventType](/api/listr2/enumerations/enumeration.ListrTaskEventType.html) through [ListrTaskEventManager](/api/listr2/classes/class..ListrTaskEventManager.html) which you can subscribe.
+_Listr_ and its _Task_ fires many events to indicate the task status. _Task_ depending on what is currently done will fire [ListrTaskState](/api/listr2/enumerations/ListrTaskState.html) and [ListrTaskEventType](/api/listr2/enumerations/ListrTaskEventType.html) through [ListrTaskEventManager](/api/listr2/classes/ListrTaskEventManager.html) which you can subscribe.
 
 Take a look at _SimpleRenderer_ or _VerboseRenderer_ since it is implemented this way.
 
@@ -54,7 +54,7 @@ Take a look at _SimpleRenderer_ or _VerboseRenderer_ since it is implemented thi
 
 <Version version="v2.1.0" />
 
-Additional to listening to the events, another singleton hook that come from the root _Listr_ is `events`. This provides some generic events like [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/enumeration.ListrEventType.html#should-refresh-render) which can be used to trigger an update on an updating renderer.
+Additional to listening to the events, another singleton hook that come from the root _Listr_ is `events`. This provides some generic events like [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/ListrEventType.html#should-refresh-render) which can be used to trigger an update on an updating renderer.
 
 These `events` can be the third optional variable of a given renderer while using it is always optional.
 

--- a/docs/renderer/default.md
+++ b/docs/renderer/default.md
@@ -23,7 +23,7 @@ This renderer uses _ProcessOutput_ to take control of the terminal.
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md -->
 
 :::
 
@@ -31,6 +31,6 @@ This renderer uses _ProcessOutput_ to take control of the terminal.
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererTaskOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererTaskOptions.md -->
 
 :::

--- a/docs/renderer/fallback-condition.md
+++ b/docs/renderer/fallback-condition.md
@@ -47,7 +47,7 @@ These checks are primal at best but do not forget that in many cases, your termi
 
 ::: info Example
 
-You can find the related examples [here](https://github.com/listr2/listr2/tree/master/examples/renderer-fallback-condition.example.ts).
+You can find the related examples [here](../../examples/renderer-fallback-condition.example.ts).
 
 :::
 

--- a/docs/renderer/fallback-condition.md
+++ b/docs/renderer/fallback-condition.md
@@ -47,7 +47,7 @@ These checks are primal at best but do not forget that in many cases, your termi
 
 ::: info Example
 
-You can find the related examples [here](../../examples/renderer-fallback-condition.example.ts).
+You can find the related examples [here](https://github.com/listr2/listr2/tree/master/examples/renderer-fallback-condition.example.ts).
 
 :::
 

--- a/docs/renderer/logger.md
+++ b/docs/renderer/logger.md
@@ -10,7 +10,7 @@ category:
 
 # {{ $frontmatter.title }}
 
-[ListrLogger](/api/listr2/classes/class..ListrLogger.html) is a common interface that enables the renderers to have a certain output format.
+[ListrLogger](/api/listr2/classes/ListrLogger.html) is a common interface that enables the renderers to have a certain output format.
 
 <!-- more -->
 
@@ -20,11 +20,11 @@ _ListrLogger_ is used for every renderer to a certain degree. _ListrLogger_ is a
 
 Log levels for the _ListrLogger_ are dynamically injected while creating an instance of _ListrLogger_ and will affect the styling section of the instance.
 
-By default, [ListrLogLevels](/api/listr2/enumerations/enumeration.ListrLogLevels.html) is used for text-based renderers. For renderers like _DefaultRenderer_ styling require more cases than usual compared to the text-based renderers, therefore custom log levels [ListrDefaultRendererListrLogLevels](/api/listr2/enumerations/enumeration.ListrDefaultRendererListrLogLevels.html) are injected.
+By default, [ListrLogLevels](/api/listr2/enumerations/ListrLogLevels.html) is used for text-based renderers. For renderers like _DefaultRenderer_ styling require more cases than usual compared to the text-based renderers, therefore custom log levels [ListrDefaultRendererListrLogLevels](/api/listr2/enumerations/ListrDefaultRendererListrLogLevels.html) are injected.
 
 ## Style
 
-The _style_ of _ListrLogger_ can be customized through [ListrLoggerOptions](/api/listr2/interfaces/interface.ListrLoggerOptions.html). Since every renderer in some form is using _ListrLogger_ this functionality can be used to customize the renderers directly without implementing your renderer.
+The _style_ of _ListrLogger_ can be customized through [ListrLoggerOptions](/api/listr2/interfaces/ListrLoggerOptions.html). Since every renderer in some form is using _ListrLogger_ this functionality can be used to customize the renderers directly without implementing your renderer.
 
 ### Icons and Colors
 
@@ -32,7 +32,7 @@ The _style_ of _ListrLogger_ can be customized through [ListrLoggerOptions](/api
 
 _ListrLogger_ can be customized for any renderer through the exposed fields on your renderer inside the respective renderer options that use the _ListrLogger_.
 
-The `icon` and `color` section of the supported renderer is in the form of [ListrLoggerStyleMap](/api/listr2/interfaces/interface.ListrLoggerStyleMap.html). By injecting new style options into the _ListrLogger_ you can change the icons and colors of every possible task.
+The `icon` and `color` section of the supported renderer is in the form of [ListrLoggerStyleMap](/api/listr2/interfaces/ListrLoggerStyleMap.html). By injecting new style options into the _ListrLogger_ you can change the icons and colors of every possible task.
 
 ::: details <CodeExampleIcon /> Code Example
 
@@ -52,7 +52,7 @@ Please refer to the _presets_ section for how to use this with the renderers.
 
 <Version version="v6.0.0" />
 
-The Preset mechanism is used for displaying additional data like [timestamps](/api/variables/listr2.PRESET_TIMESTAMP.html) or [timers](/api/variables/listr2.PRESET_TIMER.html). This also gives flexibility to making things dynamic with a conditional display of fields or conditional styling.
+The Preset mechanism is used for displaying additional data like [timestamps](/api/listr2/variables/PRESET_TIMESTAMP.html) or [timers](/api/listr2/variables/PRESET_TIMER.html). This also gives flexibility to making things dynamic with a conditional display of fields or conditional styling.
 
 Different renderers support different presets, depending on whether it fits in the style of the selected renderer. Presets are not directly tied with the _ListrLogger_ itself but it is mostly leveraging the mechanism to have fields in the sense of prefixes and suffixes in the logging entry.
 

--- a/docs/renderer/process-output.md
+++ b/docs/renderer/process-output.md
@@ -10,7 +10,7 @@ category:
 
 # {{ $frontmatter.title }}
 
-[ProcessOutput](/api/listr2/classes/class..ProcessOutput.html), [ProcessOutputStream](/api/listr2/classes/class..ProcessOutputStream.html), [ProcessOutputBuffer](/api/listr2/classes/class..ProcessOutputBuffer.html) is used to take control of the current `stdout` and `stderr` for _ListrLogger_ to ensure that nothing else is written to the console and creates an abstraction for accessing `process.stdout` and `process.stderr` when needed.
+[ProcessOutput](/api/listr2/classes/ProcessOutput.html), [ProcessOutputStream](/api/listr2/classes/ProcessOutputStream.html), [ProcessOutputBuffer](/api/listr2/classes/ProcessOutputBuffer.html) is used to take control of the current `stdout` and `stderr` for _ListrLogger_ to ensure that nothing else is written to the console and creates an abstraction for accessing `process.stdout` and `process.stderr` when needed.
 
 <!-- more -->
 
@@ -18,7 +18,7 @@ category:
 
 ## Hijack
 
-[ProcessOutput](/api/listr2/classes/class..ProcessOutput.html) for renderers like _DefaultRenderer_ that need updating your `vt100` compatible terminal gives the ability to hijack the current `process.stdout` and `process.stderr`, create a temporary buffer for storing anything that is trying to write to the terminal since it will corrupt the output of _Listr_. If the renderer does not request to hijack the terminal output, `process.stdout` and `process.stderr` will be used directly without any trickery.
+[ProcessOutput](/api/listr2/classes/ProcessOutput.html) for renderers like _DefaultRenderer_ that need updating your `vt100` compatible terminal gives the ability to hijack the current `process.stdout` and `process.stderr`, create a temporary buffer for storing anything that is trying to write to the terminal since it will corrupt the output of _Listr_. If the renderer does not request to hijack the terminal output, `process.stdout` and `process.stderr` will be used directly without any trickery.
 
 ## Release
 

--- a/docs/renderer/simple.md
+++ b/docs/renderer/simple.md
@@ -21,7 +21,7 @@ _SimpleRenderer_ still requires `vt100` terminal compatibility if you are using 
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrSimpleRendererOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrSimpleRendererOptions.md -->
 
 :::
 
@@ -29,6 +29,6 @@ _SimpleRenderer_ still requires `vt100` terminal compatibility if you are using 
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrSimpleRendererTaskOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrSimpleRendererTaskOptions.md -->
 
 :::

--- a/docs/renderer/test.md
+++ b/docs/renderer/test.md
@@ -12,7 +12,7 @@ category:
 
 _TestRenderer_ is intended to use in tests and provides a per-line JSON format output, that is configurable through the renderer options.
 
-This JSON format specific can be seen [here](/api/listr2/interfaces/interface.TestRendererSerializerOutput.html), but needs a better understanding of internal workings of this library.
+This JSON format specific can be seen [here](/api/listr2/interfaces/TestRendererSerializerOutput.html), but needs a better understanding of internal workings of this library.
 
 <!-- more -->
 
@@ -20,6 +20,6 @@ This JSON format specific can be seen [here](/api/listr2/interfaces/interface.Te
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrTestRendererOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrTestRendererOptions.md -->
 
 :::

--- a/docs/renderer/verbose.md
+++ b/docs/renderer/verbose.md
@@ -19,7 +19,7 @@ _VerboseRenderer_ is the default `non-TTY` renderer and works mostly like a logg
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrVerboseRendererOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrVerboseRendererOptions.md -->
 
 :::
 
@@ -27,6 +27,6 @@ _VerboseRenderer_ is the default `non-TTY` renderer and works mostly like a logg
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrVerboseRendererTaskOptions.md -->
+<!-- @include: ../api/listr2/interfaces/ListrVerboseRendererTaskOptions.md -->
 
 :::

--- a/docs/repository/contributions.md
+++ b/docs/repository/contributions.md
@@ -27,7 +27,7 @@ Swapping updating renderer [`log-update`](https://www.npmjs.com/package/log-upda
 
 #### Problems with Current Implementation
 
-- For sufficiently long task lists, the flashing effect happens due to it updating the whole screen whenever [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/enumeration.ListrEventType.html#should-refresh-render) is triggered by the parent task indicating a new render should be done.
+- For sufficiently long task lists, the flashing effect happens due to it updating the whole screen whenever [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/ListrEventType.html#should-refresh-render) is triggered by the parent task indicating a new render should be done.
 - Most of the issues are opened about _Listr_ breaking or corrupting the terminal output. This sometimes causes unintended behavior.
 - It brings a lot of overhead of wrapping and truncating the lines again inside the default renderer since the built-in one does not seem to work for our case.
 

--- a/docs/task/error-handling.md
+++ b/docs/task/error-handling.md
@@ -71,7 +71,7 @@ Default renderer has options where you can change how the errors are displayed.
 
 ::: details Interface
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererOptions.md{225,259} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{225,259} -->
 
 :::
 
@@ -95,11 +95,11 @@ You can disable the error collection completely by setting it to `false`.
 
 ### ListrError
 
-[`ListrError`](/api/listr2/classes/class..ListrError.html) class extends the default `Error` and has some additional information like the cause of the error and where it is coming from, and the frozen context at the given time to further debug the issue while execution.
+[`ListrError`](/api/listr2/classes/ListrError.html) class extends the default `Error` and has some additional information like the cause of the error and where it is coming from, and the frozen context at the given time to further debug the issue while execution.
 
 ### ListrErrorTypes
 
-A listr error can be caused by multiple reasons, for a better explanation of why that particular error occurred, a type property on the `ListrError` exists in the form of enum [`ListrErrorTypes`](/api/listr2/enumerations/enumeration.ListrErrorTypes.html).
+A listr error can be caused by multiple reasons, for a better explanation of why that particular error occurred, a type property on the `ListrError` exists in the form of enum [`ListrErrorTypes`](/api/listr2/enumerations/ListrErrorTypes.html).
 
 ### Methodology
 

--- a/docs/task/retry.md
+++ b/docs/task/retry.md
@@ -36,7 +36,7 @@ Retry action can have a delay between the tries. For enabling this behavior, you
 
 ## Retry Event
 
-Retrying is self-aware, and you can access the task if it is retrying via `task.isRetrying()`. It will either return an object [with the given interface](/api/listr2/interfaces/interface.ListrTaskRetry.html) where the `count` will be `0` for not repeating tasks, and `withError` is the last encountered error if retrying.
+Retrying is self-aware, and you can access the task if it is retrying via `task.isRetrying()`. It will either return an object [with the given interface](/api/listr2/interfaces/ListrTaskRetry.html) where the `count` will be `0` for not repeating tasks, and `withError` is the last encountered error if retrying.
 
 ### Retry Count
 
@@ -54,6 +54,6 @@ Retrying is self-aware, and you can access the task if it is retrying via `task.
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererOptions.md{263,294} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{263,294} -->
 
 :::

--- a/docs/task/skip.md
+++ b/docs/task/skip.md
@@ -46,6 +46,6 @@ The default renderer has options where you can change how the skip messages are 
 
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/interface.ListrDefaultRendererOptions.md{168,221} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{168,221} -->
 
 :::

--- a/docs/task/task-options.md
+++ b/docs/task/task-options.md
@@ -16,11 +16,11 @@ category:
 
 ## Per _Listr_
 
-_Listr_ task list can be configured how to behave globally by using the second argument of the prototype with [given properties](/api/listr2/interfaces/interface.ListrOptions.html#properties).
+_Listr_ task list can be configured how to behave globally by using the second argument of the prototype with [given properties](/api/listr2/interfaces/ListrOptions.html#properties).
 
 ## Per _Subtask_
 
-This behavior can be further expanded, if the subtask requires a different approach, in this case, these options are generated depending on the current renderer with the [given properties](/api/listr2/interfaces/interface.ListrSubClassOptions.html#properties).
+This behavior can be further expanded, if the subtask requires a different approach, in this case, these options are generated depending on the current renderer with the [given properties](/api/listr2/interfaces/ListrSubClassOptions.html#properties).
 
 Naturally, subtasks options are a subset of the general options, since some options are needed to be set only one time, and do not make sense to change per task.
 

--- a/docs/task/task.md
+++ b/docs/task/task.md
@@ -10,13 +10,13 @@ category:
 
 # {{ $frontmatter.title }}
 
-`listr2` is a collection of tasks that are housed in a single instance as we have just created. Therefore the [Task](/api/listr2/interfaces/interface.ListrTask.html) is the smallest building block of your task list.
+`listr2` is a collection of tasks that are housed in a single instance as we have just created. Therefore the [Task](/api/listr2/interfaces/ListrTask.html) is the smallest building block of your task list.
 
 <!-- more -->
 
 ## Task
 
-A single task is an object with the [given properties](/api/listr2/interfaces/interface.ListrTask.html#properties), where the `task` is the main attraction that the desired function gets executed.
+A single task is an object with the [given properties](/api/listr2/interfaces/ListrTask.html#properties), where the `task` is the main attraction that the desired function gets executed.
 
 A task can be in the form of, which is ensured by the typings:
 


### PR DESCRIPTION
Currently the documentation has many imports that result in empty Options toggles on the documentation website (e.g. https://listr2.kilic.dev/renderer/default.html) which seems to have resulted from typedoc not generating files with a type prefix anymore.

I tried to find all occurances of imports where the paths would be incorrect and hopefully fixed them.

I cannot remember what the docs initially looked like, but attached a screenshot of what the expanded options looks like now. Probably not idea but the best temporary solution for now if you want to keep dev frustration down from having to somehow try and figure out what the class options are.
![image](https://github.com/listr2/listr2/assets/124467/a3f928f5-bbb0-48df-94e8-08f85a5f091d)