### PR TITLE
Fix issues with adding/removing SIGINT listeners

### DIFF
--- a/packages/listr2/tests/signal-handler.e2e-spec.ts
+++ b/packages/listr2/tests/signal-handler.e2e-spec.ts
@@ -80,4 +80,25 @@ describe('signal handlers', () => {
 
     expectProcessOutputToMatchSnapshot(output, 'ACxcRBILlHsqiSxYArjASFdofVqLaUyE')
   })
+
+  it('should not clear other SIGINT listeners', async () => {
+    process.addListener('SIGINT', function doNotRemove () {})
+    expect(process.listeners('SIGINT').map((listener) => listener.name)).toContain('doNotRemove')
+
+    await new Listr(
+      [
+        {
+          title: 'a task',
+          task: async (): Promise<void> => {}
+        }
+      ],
+      {
+        concurrent: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    ).run()
+
+    expect(process.listeners('SIGINT').map((listener) => listener.name)).toContain('doNotRemove')
+  })
 })


### PR DESCRIPTION
Closes #709 

This PR fixes the problem where Listr is removing all `SIGINT` listeners, instead of just the listeners it manages. I added a "should not clear other SIGINT listeners" test and verified it failed prior to implementing the fix. Now the test passes.