### PR TITLE
fix(deps): Move listr2 from devDep to peerDep for prompt adapters

### DIFF
--- a/packages/prompt-adapter-enquirer/package.json
+++ b/packages/prompt-adapter-enquirer/package.json
@@ -71,10 +71,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "listr2": "workspace:*",
     "enquirer": "^2.4.1"
   },
   "peerDependencies": {
-    "enquirer": ">= 2.3.0 < 3"
+    "enquirer": ">= 2.3.0 < 3",
+    "listr2": "workspace:*"
   }
 }

--- a/packages/prompt-adapter-inquirer/package.json
+++ b/packages/prompt-adapter-inquirer/package.json
@@ -74,10 +74,10 @@
   },
   "devDependencies": {
     "@inquirer/input": "^2.1.9",
-    "@inquirer/prompts": "^5.0.5",
-    "listr2": "workspace:*"
+    "@inquirer/prompts": "^5.0.5"
   },
   "peerDependencies": {
-    "@inquirer/prompts": ">= 3 < 6"
+    "@inquirer/prompts": ">= 3 < 6",
+    "listr2": "workspace:*"
   }
 }


### PR DESCRIPTION
listr2 needs to be a peer dependency and not a devDependency for package managers to install everything properly.

With `foo` and `bar` both depending on listr2 v6.6.1 and `baz` depending on listr2 v8.2.3 and `baz` also needing `@listr2/prompt-adapter-enquirer` this is what I end up with after installing

```
node_modules
├── @listr2
│   └── prompt-adapter-enquirer
│       └── v2.0.10
├── bar
├── foo
├── listr2
│   └── v6.6.1
└── baz
    └── node_modules
        └── listr2
            └── v8.2.3
```

The problem here is that when `@listr2/prompt-adapter-enquirer` does `import { something } from 'listr2'` node will resolve `listr2` to the one in `node_modules/listr2` which is v6.6.1, but `@listr2/prompt-adapter-enquirer` needs v8, so the app crashes.

With the change in this PR I instead get this tree

```
node_modules
├── @listr2
│   └── prompt-adapter-enquirer
│       └── v2.0.10
├── bar
│   └── node_modules
│       └── listr2
│           └── v6.6.1
├── foo
│   └── node_modules
│       └── listr2
│           └── v6.6.1
├── listr2
│   └── v8.2.3
└── baz
```

`@listr2/prompt-adapter-enquirer` will still resolve `listr2` to the one in the root `node_modules`, but now that is correct, since it's v8.2.3

I published a version of `@listr2/prompt-adapter-enquirer` with this change to more easily test it in a project https://verdaccio.tobbe.dev/-/web/detail/@listr2/prompt-adapter-enquirer