### PR TITLE
Switch to defaults for Listr generic type

### DIFF
--- a/packages/listr2/src/lib/task-wrapper.ts
+++ b/packages/listr2/src/lib/task-wrapper.ts
@@ -65,7 +65,7 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory, FallbackRen
     | ListrTask<NewCtx, Renderer, FallbackRenderer>[]
     | ((parent: Omit<this, 'skip' | 'enabled'>) => ListrTask<NewCtx, Renderer, FallbackRenderer> | ListrTask<NewCtx, Renderer, FallbackRenderer>[]),
     options?: ListrSubClassOptions<NewCtx, Renderer, FallbackRenderer>
-  ): Listr<NewCtx, any, any> {
+  ): Listr<NewCtx> {
     let tasks: ListrTask<NewCtx, Renderer, FallbackRenderer> | ListrTask<NewCtx, Renderer, FallbackRenderer>[]
 
     if (typeof task === 'function') {
@@ -74,7 +74,7 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory, FallbackRen
       tasks = task
     }
 
-    return new Listr<NewCtx, any, any>(tasks, options, this.task)
+    return new Listr<NewCtx>(tasks, options, this.task)
   }
 
   /**


### PR DESCRIPTION
Hey @cenk1cenk2, hope you're well! 👋

Just ran across this error from [`@typescript-eslint/no-unsafe-return`](https://typescript-eslint.io/rules/no-unsafe-return/) just now:

```
Unsafe return of type `Listr<any, any, any>` from function with return type `Listr<any, "default", "simple">`. eslint (@typescript-eslint/no-unsafe-return)
```

![Screenshot 2024-07-19 at 14 14 12](https://github.com/user-attachments/assets/be739787-57a2-40ba-9859-ed4e87b703f7)

From this code:

https://github.com/upleveled/preflight/blob/f0ab39f358bcb58dd535e2d8c3e3ffd703a1244a/src/index.ts#L28-L57

Seems like the type of `Listr` (defaults of `'default'` and `'simple'` for generic type arguments) and the return type of `task.newListr()` don't match, which causes this type incompatibility.

In this PR, I have discarded the 2 `any` values to allow for the defaults to take over.

Thoughts?