### PR TITLE
fix: renderer maybe undefined

### DIFF
--- a/packages/listr2/src/listr.ts
+++ b/packages/listr2/src/listr.ts
@@ -223,7 +223,7 @@ export class Listr<
 
     // only the parent task shall exit
     if (this.isRoot()) {
-      this.renderer.end(new Error('Interrupted.'))
+      this.renderer?.end(new Error('Interrupted.'))
 
       process.exit(127)
     }


### PR DESCRIPTION
initialize a listr instance, and **don't** call `run`, press `CTRL+C` will throw exception like this:

```shell
? 💬 ^C2286 |       if (task.isPending()) {
2287 |         task.state$ = "FAILED" /* FAILED */;
2288 |       }
2289 |     });
2290 |     if (this.isRoot()) {
2291 |       this.renderer.end(new Error("Interrupted."));
                  ^
TypeError: undefined is not an object (evaluating 'this.renderer.end')
```

so we need to ignore renderer if it not defined