### PR TITLE
feat: support write output to stdout by enable `writeBottomBarDirectly`

### DIFF
--- a/packages/listr2/src/renderer/default/renderer.interface.ts
+++ b/packages/listr2/src/renderer/default/renderer.interface.ts
@@ -146,6 +146,14 @@ export interface ListrDefaultRendererOptions
    * @defaultValue `PRESET_TIMER`
    */
   pausedTimer?: PresetTimer
+
+  /**
+   * Directly write the output to the stdout stream (just like a normal console.log) instead of the bottom bar.
+   * It needs to enable `bottomBar` option to work.
+   *
+   * @defaultValue `false`
+   */
+  writeBottomBarDirectly?: boolean
 }
 
 export interface ListrDefaultRendererTaskOptions extends RendererPresetTimer {

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -109,7 +109,13 @@ export class DefaultRenderer implements ListrRenderer {
   }
 
   public update (): void {
-    this.updater(this.create())
+    const [ tasks, output ] = this.create()
+
+    if (output) {
+      this.updater.clear()
+      this.logger.process.toStdout(output)
+    }
+    this.updater(tasks)
   }
 
   public end (): void {
@@ -119,15 +125,21 @@ export class DefaultRenderer implements ListrRenderer {
     this.updater.clear()
     this.updater.done()
 
+    const [ tasks, output ] = this.create({ prompt: false })
+
+    if (output) {
+      this.logger.process.toStdout(output)
+    }
+
     // directly write to process.stdout, since logupdate only can update the seen height of terminal
     if (!this.options.clearOutput) {
-      this.logger.process.toStdout(this.create({ prompt: false }))
+      this.logger.process.toStdout(tasks)
     }
 
     this.logger.process.release()
   }
 
-  public create (options?: { tasks?: boolean, bottomBar?: boolean, prompt?: boolean }): string {
+  public create (options?: { tasks?: boolean, bottomBar?: boolean, prompt?: boolean }): [string, string | undefined] {
     options = {
       tasks: true,
       bottomBar: true,
@@ -145,12 +157,14 @@ export class DefaultRenderer implements ListrRenderer {
       render.push(...renderTasks)
     }
 
-    if (options.bottomBar && renderBottomBar.length > 0) {
-      if (render.length > 0) {
-        render.push('')
-      }
+    if (!this.options.writeBottomBarDirectly) {
+      if (options.bottomBar && renderBottomBar.length > 0) {
+        if (render.length > 0) {
+          render.push('')
+        }
 
-      render.push(...renderBottomBar)
+        render.push(...renderBottomBar)
+      }
     }
 
     if (options.prompt && renderPrompt.length > 0) {
@@ -161,7 +175,7 @@ export class DefaultRenderer implements ListrRenderer {
       render.push(...renderPrompt)
     }
 
-    return render.join(EOL)
+    return [ render.join(EOL), this.options.writeBottomBarDirectly ? renderBottomBar.join(EOL) : undefined ]
   }
 
   // eslint-disable-next-line complexity
@@ -455,7 +469,15 @@ export class DefaultRenderer implements ListrRenderer {
     }
 
     return Array.from(this.buffer.bottom.values())
-      .flatMap((output) => output.all)
+      .flatMap((output) => {
+        const o = output.all.slice(0)
+
+        if (this.options.writeBottomBarDirectly) {
+          output.reset()
+        }
+
+        return o
+      })
       .sort((a, b) => a.time - b.time)
       .map((output) => output.entry)
   }


### PR DESCRIPTION
There is not a way to print log to the stdout directly for default renderer. UX is bad when the tasks and output is too large.
Currently you can enable `writeBottomBarDirectly` to write the output to stdout and keep the tasks progressing in the bottom of terminal, and you can also scroll screen to view the whole logs (before you have to waiting for the listr closed).

```ts
    new Listr(
      [
        {
          title: "call agent xxx",
          task: () => {},
          rendererOptions: {
            outputBar: Number.POSITIVE_INFINITY,
            bottomBar: Number.POSITIVE_INFINITY,
          },
        },
      ],
      {
        concurrent: true,
        rendererOptions: {
          timer: PRESET_TIMER,
          collapseSubtasks: false,
          writeBottomBarDirectly: true,
        },
      },
    );
```

![Kapture 2025-04-10 at 15 59 27](https://github.com/user-attachments/assets/aff548d2-c2fc-4e26-a460-a8c06acac263)
