### PR TITLE
fix: set TTY env before getRenderer

### DIFF
--- a/packages/listr2/src/listr.ts
+++ b/packages/listr2/src/listr.ts
@@ -80,6 +80,17 @@ export class Listr<
       this.events = new ListrEventManager()
     }
 
+    /* istanbul ignore if */
+    if (this.options?.forceTTY || process.env[ListrEnvironmentVariables.FORCE_TTY]) {
+      process.stdout.isTTY = true
+      process.stderr.isTTY = true
+    }
+
+    /* istanbul ignore if */
+    if (this.options?.forceUnicode) {
+      process.env[ListrEnvironmentVariables.FORCE_UNICODE] = '1'
+    }
+
     // get renderer class
     const renderer = getRenderer({
       renderer: this.options.renderer,
@@ -103,17 +114,6 @@ export class Listr<
     if (this.options.registerSignalListeners) {
       this.boundSignalHandler = this.signalHandler.bind(this)
       process.once('SIGINT', this.boundSignalHandler).setMaxListeners(0)
-    }
-
-    /* istanbul ignore if */
-    if (this.options?.forceTTY || process.env[ListrEnvironmentVariables.FORCE_TTY]) {
-      process.stdout.isTTY = true
-      process.stderr.isTTY = true
-    }
-
-    /* istanbul ignore if */
-    if (this.options?.forceUnicode) {
-      process.env[ListrEnvironmentVariables.FORCE_UNICODE] = '1'
     }
   }
 


### PR DESCRIPTION
getRenderer relies on process.stdout.isTTY to determine the renderer.

Previously, the environment variable logic (e.g., forceTTY) was set after calling getRenderer, which could lead to incorrect renderer selection.

This change moves the environment variable setup before getRenderer to ensure the correct renderer is chosen.
