### PR TITLE
docs: fix types in `process-output/change-behavior` example

### DIFF
--- a/examples/docs/renderer/process-output/change-behavior.ts
+++ b/examples/docs/renderer/process-output/change-behavior.ts
@@ -35,7 +35,7 @@ const tasks = new Listr(
   {
     concurrent: true,
     rendererOptions: {
-      logger: new ListrLogger({ processOutput: new ProcessOutput(null, null, { dump: [] }) })
+      logger: new ListrLogger({ processOutput: new ProcessOutput(undefined, undefined, { dump: [] }) })
     }
   }
 )


### PR DESCRIPTION
The `stdout` and `stderr` parameters for the `ProcessOutput` constructor take in `NodeJS.WriteStream | undefined`, so passing in `null` as the current example does throws the following TypeScript error:

```
Argument of type 'null' is not assignable to parameter of type 'WriteStream | undefined'.ts(2345)
```

https://github.com/listr2/listr2/blob/1e57e090dacd904ea259d8c1518c8bdb91ba3ff1/packages/listr2/src/utils/process-output/process-output.ts#L20-L21