### PR TITLE
fix: list `listr2` as a peer dependency

### DIFF
--- a/packages/prompt-adapter-enquirer/package.json
+++ b/packages/prompt-adapter-enquirer/package.json
@@ -69,12 +69,12 @@
     "wait",
     "idle"
   ],
-  "dependencies": {},
   "devDependencies": {
     "listr2": "workspace:*",
     "enquirer": "^2.4.1"
   },
   "peerDependencies": {
-    "enquirer": ">= 2.3.0 < 3"
+    "enquirer": ">= 2.3.0 < 3",
+    "listr2": "^8.0.0"
   }
 }

--- a/packages/prompt-adapter-inquirer/package.json
+++ b/packages/prompt-adapter-inquirer/package.json
@@ -78,6 +78,7 @@
     "listr2": "workspace:*"
   },
   "peerDependencies": {
-    "@inquirer/prompts": ">= 3 < 8"
+    "@inquirer/prompts": ">= 3 < 8",
+    "listr2": "^8.0.0"
   }
 }


### PR DESCRIPTION
Since `listr2` is required at runtime, it should be declared as a peer dependency.