### PR TITLE
Update examples.md

### DIFF
--- a/docs/listr/examples.md
+++ b/docs/listr/examples.md
@@ -24,6 +24,9 @@ git clone git@github.com:cenk1cenk2/listr2.git
 # install the dependencies
 pnpm install
 
+# build packages
+pnpm build
+
 # run any example, by giving the script a relative path in the repository
 pnpm run --filter example start renderer-default.example.ts
 ```


### PR DESCRIPTION
The examples do not work without building first because the "dist" directory is missing.  occurred to me on 

```
pnpm run --filter examples start renderer-default.example.ts

> @listr2/examples@1.0.0 start /workspaces/listr2/examples
> NODE_OPTIONS='--no-warnings --experimental-specifier-resolution=node --experimental-vm-modules --loader ./loader.js' node renderer-default.example.ts


node:internal/modules/run_main:123
    triggerUncaughtException(
    ^
Error: Cannot find module '/workspaces/listr2/examples/node_modules/@listr2/prompt-adapter-enquirer/dist/index.js' imported from /workspaces/listr2/examples/renderer-default.example.ts
```

worked properly after build