### PR TITLE
Add `type` keyword to export to avoid runtime class exports

### DIFF
--- a/packages/listr2/src/interfaces/index.ts
+++ b/packages/listr2/src/interfaces/index.ts
@@ -1,5 +1,3 @@
-import type { Task, TaskWrapper } from '@lib'
-
 export type * from './data.interface'
 export * from './event.interface'
 export * from './listr-error.interface'
@@ -11,4 +9,4 @@ export * from './prompt-error.interface'
 export * from './renderer.interface'
 export type * from './task.interface'
 
-export type { Task as ListrTaskObject, TaskWrapper as ListrTaskWrapper }
+export type { Task as ListrTaskObject, TaskWrapper as ListrTaskWrapper } from '@lib'


### PR DESCRIPTION
Closes #745

Maybe this is what tsc / tsdown need to get the `type` keyword into the export in [`dist/index.d.ts`](https://github.com/listr2/listr2/issues/745#issuecomment-3209982268), via one of:

- `export type { TaskWrapper as ListrTaskWrapper };`
- `export { type TaskWrapper as ListrTaskWrapper };`

If this approach doesn't work, then maybe `TaskWrapper as ListrTaskWrapper` is exported somewhere else in the codebase as class?