### PR TITLE
feat(lib): replace eventemitter3 with Node built-in EventEmitter

### DIFF
--- a/packages/listr2/package.json
+++ b/packages/listr2/package.json
@@ -71,7 +71,6 @@
   ],
   "dependencies": {
     "cli-truncate": "^5.2.0",
-    "eventemitter3": "^5.0.4",
     "log-update": "^6.1.0",
     "rfdc": "^1.4.1",
     "wrap-ansi": "^10.0.0"

--- a/packages/listr2/src/lib/event-manager.ts
+++ b/packages/listr2/src/lib/event-manager.ts
@@ -1,6 +1,5 @@
-import EventEmitter from 'eventemitter3'
-
 import type { EventData } from '@interfaces'
+import EventEmitter from 'node:events'
 
 export class EventManager<Event extends string = string, Map extends Partial<Record<Event, unknown>> = Partial<Record<Event, any>>> {
   private readonly emitter = new EventEmitter()
@@ -10,14 +9,26 @@ export class EventManager<Event extends string = string, Map extends Partial<Rec
   }
 
   public on<E extends Event = Event>(dispatch: E, handler: (data: EventData<E, Map>) => void): void {
+    if (!handler) {
+      return
+    }
+
     this.emitter.addListener(dispatch, handler)
   }
 
   public once<E extends Event = Event>(dispatch: E, handler: (data: EventData<E, Map>) => void): void {
+    if (!handler) {
+      return
+    }
+
     this.emitter.once(dispatch, handler)
   }
 
   public off<E extends Event = Event>(dispatch: E, handler?: (data: EventData<E, Map>) => void): void {
+    if (!handler) {
+      return
+    }
+
     this.emitter.off(dispatch, handler)
   }
 

--- a/packages/listr2/src/lib/event-manager.ts
+++ b/packages/listr2/src/lib/event-manager.ts
@@ -1,8 +1,13 @@
-import type { EventData } from '@interfaces'
 import EventEmitter from 'node:events'
+
+import type { EventData } from '@interfaces'
 
 export class EventManager<Event extends string = string, Map extends Partial<Record<Event, unknown>> = Partial<Record<Event, any>>> {
   private readonly emitter = new EventEmitter()
+
+  constructor() {
+    this.emitter.setMaxListeners(0)
+  }
 
   public emit<E extends Event = Event>(dispatch: E, args?: EventData<E, Map>): void {
     this.emitter.emit(dispatch, args)
@@ -25,11 +30,11 @@ export class EventManager<Event extends string = string, Map extends Partial<Rec
   }
 
   public off<E extends Event = Event>(dispatch: E, handler?: (data: EventData<E, Map>) => void): void {
-    if (!handler) {
-      return
+    if (handler) {
+      this.emitter.off(dispatch, handler)
+    } else {
+      this.emitter.removeAllListeners(dispatch)
     }
-
-    this.emitter.off(dispatch, handler)
   }
 
   public complete(): void {

--- a/packages/prompt-adapter-enquirer/tests/__snapshots__/prompt-enquirer.e2e-spec.ts.snap
+++ b/packages/prompt-adapter-enquirer/tests/__snapshots__/prompt-enquirer.e2e-spec.ts.snap
@@ -132,7 +132,12 @@ exports[`default renderer: prompt -> enquirer should use skip enquirer: 8QRF9bQE
   "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.
 [2m◼[22m Another task.
 ",
-  "[2K[1A[2K[1A[2K[G[2m◼[22m This task will execute.
+  "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.
+[2m◼[22m Another task.
+
+[32m✔[39m [1mGive me some input.[22m [2m·[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G[2m◼[22m This task will execute.
 [2m◼[22m Another task.
 ",
   "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.

--- a/packages/prompt-adapter-enquirer/tests/__snapshots__/prompt-enquirer.e2e-spec.ts.snap
+++ b/packages/prompt-adapter-enquirer/tests/__snapshots__/prompt-enquirer.e2e-spec.ts.snap
@@ -132,12 +132,7 @@ exports[`default renderer: prompt -> enquirer should use skip enquirer: 8QRF9bQE
   "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.
 [2m◼[22m Another task.
 ",
-  "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.
-[2m◼[22m Another task.
-
-[32m✔[39m [1mGive me some input.[22m [2m·[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G[2m◼[22m This task will execute.
+  "[2K[1A[2K[1A[2K[G[2m◼[22m This task will execute.
 [2m◼[22m Another task.
 ",
   "[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.

--- a/packages/prompt-adapter-enquirer/tests/prompt-enquirer.e2e-spec.ts
+++ b/packages/prompt-adapter-enquirer/tests/prompt-enquirer.e2e-spec.ts
@@ -207,14 +207,22 @@ describe.each<RendererSetup>(RENDERER_SETUP)('%s renderer: prompt -> enquirer', 
         {
           title: 'This task will execute.',
           task: async(ctx, task): Promise<void> => {
-            delay(10)
-              .then(() => task.skip())
-              .catch(() => {})
+            const prompt = task.prompt(ListrEnquirerPromptAdapter)
 
-            ctx.output = await task.prompt(ListrEnquirerPromptAdapter).run({
+            const result = prompt.run({
               type: 'Input',
               message: 'Give me some input.'
             })
+
+            await delay(100)
+
+            task.skip()
+
+            try {
+              ctx.output = await result
+            } catch {
+              ctx.output = ''
+            }
           }
         },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,9 +150,6 @@ importers:
       cli-truncate:
         specifier: ^5.2.0
         version: 5.2.0
-      eventemitter3:
-        specifier: ^5.0.4
-        version: 5.0.4
       log-update:
         specifier: ^6.1.0
         version: 6.1.0


### PR DESCRIPTION
Replace `eventemitter3` with Node's built-in `EventEmitter` from `node:events`.

- Swap import from `eventemitter3` to `node:events` in `event-manager.ts`.
- Branch `off()` to call `removeAllListeners` when no handler is provided — preserves eventemitter3's "remove all listeners for event" semantics that both renderer call sites rely on.
- Set `setMaxListeners(0)` in the `EventManager` constructor to preserve eventemitter3's unlimited-listener default.
- Remove `eventemitter3` from `package.json` dependencies and `pnpm-lock.yaml`.
- Fix race condition in the enquirer "skip enquirer" test — replace fire-and-forget `delay(10).then(skip)` with deterministic `await delay(100)` + `task.skip()`.
- Update enquirer adapter snapshot for the default renderer — one additional render frame due to listener registration order with Node's EventEmitter; visual output unchanged.

BREAKING CHANGE: `eventemitter3` is no longer a dependency of `listr2`. The internal `EventManager` now uses Node's built-in `EventEmitter` from `node:events`. While the public API is unchanged, the underlying event emitter implementation is swapped. Projects that directly referenced `eventemitter3` through `listr2`'s transitive dependencies will need to install it separately. This change requires Node.js >= 22.13.0 (already the minimum supported version).

closes #759
closes K-707