### PR TITLE
fix: buggy characters on git bash for windows

### DIFF
--- a/packages/listr2/src/utils/ui/renderer.spec.ts
+++ b/packages/listr2/src/utils/ui/renderer.spec.ts
@@ -1,8 +1,62 @@
-import { getRendererClass } from './renderer'
+import { ListrRendererSelection } from '@constants'
 import { DefaultRenderer, SilentRenderer, SimpleRenderer, TestRenderer, VerboseRenderer } from '@renderer'
+import { getRenderer, getRendererClass } from './renderer'
 
 describe('renderers', () => {
-  process.stdout.isTTY = true
+  const originalIsTTY = process.stdout.isTTY
+  const originalMSYSTEM = process.env.MSYSTEM
+  const originalComSpec = process.env.ComSpec
+  const originalNpmLifecycleEvent = process.env.npm_lifecycle_event
+  const originalNpmExecPath = process.env.npm_execpath
+  const originalNpmUserAgent = process.env.npm_config_user_agent
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    process.stdout.isTTY = true
+    delete process.env.MSYSTEM
+    delete process.env.ComSpec
+    delete process.env.npm_lifecycle_event
+    delete process.env.npm_execpath
+    delete process.env.npm_config_user_agent
+  })
+
+  afterAll(() => {
+    process.stdout.isTTY = originalIsTTY
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
+
+    if (originalMSYSTEM === undefined) {
+      delete process.env.MSYSTEM
+    } else {
+      process.env.MSYSTEM = originalMSYSTEM
+    }
+
+    if (originalComSpec === undefined) {
+      delete process.env.ComSpec
+    } else {
+      process.env.ComSpec = originalComSpec
+    }
+
+    if (originalNpmLifecycleEvent === undefined) {
+      delete process.env.npm_lifecycle_event
+    } else {
+      process.env.npm_lifecycle_event = originalNpmLifecycleEvent
+    }
+
+    if (originalNpmExecPath === undefined) {
+      delete process.env.npm_execpath
+    } else {
+      process.env.npm_execpath = originalNpmExecPath
+    }
+
+    if (originalNpmUserAgent === undefined) {
+      delete process.env.npm_config_user_agent
+    } else {
+      process.env.npm_config_user_agent = originalNpmUserAgent
+    }
+  })
 
   it('should return default renderer', () => {
     expect(getRendererClass('default').name).toEqual(DefaultRenderer.name)
@@ -22,5 +76,61 @@ describe('renderers', () => {
 
   it('should return silent renderer', () => {
     expect(getRendererClass('silent').name).toEqual(SilentRenderer.name)
+  })
+
+  it('should fallback to secondary renderer in git bash on windows when bridged through npm cmd shell', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    process.env.MSYSTEM = 'MINGW64'
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe'
+    process.env.npm_lifecycle_event = 'lint'
+
+    const renderer = getRenderer({
+      renderer: 'default',
+      rendererOptions: undefined,
+      fallbackRenderer: 'simple',
+      fallbackRendererOptions: undefined
+    })
+
+    expect(renderer.selection).toEqual(ListrRendererSelection.SECONDARY)
+    expect(renderer.renderer.name).toEqual(SimpleRenderer.name)
+  })
+
+  it('should keep primary renderer in git bash on windows when not running via npm cmd bridge', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    process.env.MSYSTEM = 'MINGW64'
+
+    const renderer = getRenderer({
+      renderer: 'default',
+      rendererOptions: undefined,
+      fallbackRenderer: 'simple',
+      fallbackRendererOptions: undefined
+    })
+
+    expect(renderer.selection).toEqual(ListrRendererSelection.PRIMARY)
+    expect(renderer.renderer.name).toEqual(DefaultRenderer.name)
+  })
+
+  it('should keep primary renderer in non-git-bash environment', () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    delete process.env.MSYSTEM
+
+    const renderer = getRenderer({
+      renderer: 'default',
+      rendererOptions: undefined,
+      fallbackRenderer: 'simple',
+      fallbackRendererOptions: undefined
+    })
+
+    expect(renderer.selection).toEqual(ListrRendererSelection.PRIMARY)
+    expect(renderer.renderer.name).toEqual(DefaultRenderer.name)
   })
 })

--- a/packages/listr2/src/utils/ui/renderer.ts
+++ b/packages/listr2/src/utils/ui/renderer.ts
@@ -1,26 +1,52 @@
 import { ListrRendererSelection } from '@constants'
 import type { ListrGetRendererOptions, ListrOptions, ListrRenderer, ListrRendererFactory, ListrRendererValue, SupportedRenderer } from '@interfaces'
 import { DefaultRenderer, SilentRenderer, SimpleRenderer, TestRenderer, VerboseRenderer } from '@renderer'
-import { assertFunctionOrSelf } from '@utils'
+import { assertFunctionOrSelf } from '../assert'
 
-const RENDERERS: Record<'default' | 'simple' | 'verbose' | 'test' | 'silent', typeof ListrRenderer> = {
-  default: DefaultRenderer,
-  simple: SimpleRenderer,
-  verbose: VerboseRenderer,
-  test: TestRenderer,
-  silent: SilentRenderer
+function getBuiltInRenderers(): Record<'default' | 'simple' | 'verbose' | 'test' | 'silent', typeof ListrRenderer> {
+  return {
+    default: DefaultRenderer,
+    simple: SimpleRenderer,
+    verbose: VerboseRenderer,
+    test: TestRenderer,
+    silent: SilentRenderer
+  }
+}
+
+function isNpmCmdBridgeInGitBashOnWindows(): boolean {
+  if (process.platform !== 'win32') {
+    return false
+  }
+
+  if (!process.env.MSYSTEM) {
+    return false
+  }
+
+  const comSpec = process.env.ComSpec?.toLowerCase()
+  const isCmdShell = comSpec?.endsWith('cmd.exe') ?? false
+  if (!isCmdShell) {
+    return false
+  }
+
+  return Boolean(process.env.npm_lifecycle_event || process.env.npm_execpath || process.env.npm_config_user_agent)
 }
 
 function isRendererSupported(renderer: ListrRendererFactory): boolean {
+  if (isNpmCmdBridgeInGitBashOnWindows() && renderer.nonTTY === false) {
+    return false
+  }
+
   return process.stdout.isTTY === true || renderer.nonTTY === true
 }
 
 export function getRendererClass(renderer: ListrRendererValue): ListrRendererFactory {
+  const renderers = getBuiltInRenderers()
+
   if (typeof renderer === 'string') {
-    return RENDERERS[renderer] ?? RENDERERS.default
+    return renderers[renderer] ?? renderers.default
   }
 
-  return typeof renderer === 'function' ? renderer : RENDERERS.default
+  return typeof renderer === 'function' ? renderer : renderers.default
 }
 
 export function getRenderer<Renderer extends ListrRendererValue, FallbackRenderer extends ListrRendererValue>(options: {


### PR DESCRIPTION
# Summary

This PR fixes garbled ANSI control output (e.g. ←[2K) in Git Bash on Windows when tasks are run via npm run (which bridges through cmd.exe).

Previously, renderer selection could pick the interactive default renderer in this path, and cursor-control updates were rendered as raw characters in some terminals.

# Root cause

The broken path is specifically:

 - process.platform === 'win32'
 - Git Bash/MSYS environment (MSYSTEM set)
 - npm script shell bridge via cmd.exe (ComSpec ends with cmd.exe)
 - npm runtime context present (npm_lifecycle_event / npm_execpath / npm_config_user_agent)

# What changed

 - Refined renderer support detection in src/utils/ui/renderer.ts:
  - Added a narrow environment guard for Windows + Git Bash + npm/cmd bridge
  - In that path, treat interactive non-nonTTY renderers as unsupported so fallback renderer is selected
 - Kept existing behavior for other environments intact
 - Added tests in src/utils/ui/renderer.spec.ts:
  - falls back in Windows Git Bash when bridged through npm/cmd
  - keeps primary renderer in Windows Git Bash when not in npm/cmd bridge (e.g. Bun case)
  - keeps primary renderer in non-Git-Bash env

# Why this scope

It works properly on bun, so we have to specifically check for npm + Git Bash.

Claude helped me write this PR.