### PR TITLE
fix(release): preserve peer dep ranges at publish time

### DIFF
--- a/.multi-releaserc.json
+++ b/.multi-releaserc.json
@@ -1,0 +1,5 @@
+{
+  "deps": {
+    "bump": "satisfy"
+  }
+}


### PR DESCRIPTION
## Summary

Add `.multi-releaserc.json` with `deps.bump=satisfy` to configure `@qiwi/multi-semantic-release` via cosmiconfig. Prevents msr from rewriting in-repo `peerDependencies` (e.g., `listr2: "^10.0.0"`) to exact version pins at publish time. Adapters will only release on their own commits or when a `listr2` major breaks the peer range.

## Root Cause

`@qiwi/multi-semantic-release` (msr) rewrites all 4 dependency scopes including `peerDependencies` with `strategy="override"` + `prefix=""` (defaults) — producing exact pins like `10.2.2` instead of preserving the authored `^10.0.0`. When `listr2` publishes without adapters also re-publishing, `pnpm install` fails with `ERR_PNPM_PEER_DEP_ISSUES`.

## Fix

```json
{
  "deps": {
    "bump": "satisfy"
  }
}
```

`bump: "satisfy"` preserves the authored peer range whenever the released `listr2` satisfies it. No changes to `.gitlab-ci.yml`, `devops/pipelines`, or the pipe image.

closes #771
closes K-704