### PR TITLE
ci: run tests on branches with a slash in their name

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -3,7 +3,7 @@ name: node
 on:
   push:
     branches:
-      - '*'
+      - '**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,7 +4,7 @@ name: coverage
 on:
   push:
     branches:
-      - '*'
+      - '**'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary

The `node` and `coverage` workflows trigger on `push` with the `*` branch glob, which only matches branch names **without** a slash. Nested branches like `agent/k-706` or `issue/gh#759` therefore never ran the test/coverage workflows on push, so changes on prefixed branches were not validated until they landed on a release branch.

## Change

- `.github/workflows/node.yml` and `.github/workflows/test-coverage.yml`: `push.branches` `'*'` → `'**'`, so every branch (including slash-prefixed ones) is tested on push.

`**` matches across `/` in GitHub Actions branch filters, while `*` matches a single path segment only.
