### PR TITLE
fix(lib): preserve OSC-8 hyperlinks in cleanseAnsi

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -13,3 +13,7 @@ order: 60
 - The _Listr_ option `collectErrors` is now a `boolean` instead of `false | 'minimal' | 'full'`. Use `true` for the previous `'minimal'` behavior, the `'full'` mode has been removed.
 - `ListrError` no longer clones the context in to the error instance and its `ctx` property has been removed. Only the `error`, its `type` and the `path` of the failed task are collected.
 - Dropped the `rfdc` dependency and removed the `cloneObject` utility from the exports, which were only used by the removed `'full'` error collection mode.
+
+## Features
+
+- [x] preserve OSC-8 hyperlinks, bells and other formatting in the task output, only stripping the cursor and erase codes that would disrupt the rendering <GithubIssue :issue="768" />

--- a/examples/task-output-formatting.example.ts
+++ b/examples/task-output-formatting.example.ts
@@ -1,0 +1,43 @@
+import { color, delay, Listr } from 'listr2'
+
+const ESC = String.fromCharCode(27)
+const BEL = String.fromCharCode(7)
+
+// OSC-8 terminal hyperlink: ESC ] 8 ; ; <url> BEL <text> ESC ] 8 ; ; BEL
+function link(url: string, text: string): string {
+  return `${ESC}]8;;${url}${BEL}${text}${ESC}]8;;${BEL}`
+}
+
+try {
+  await new Listr(
+    [
+      {
+        title: 'Emitting a terminal hyperlink through the task output.',
+        task: async(_, task): Promise<void> => {
+          task.output = `read the documentation at ${link('https://listr2.kilic.dev', 'listr2.kilic.dev')}`
+          await delay(1000)
+        },
+        rendererOptions: { persistentOutput: true }
+      },
+      {
+        title: 'Emitting a hyperlink with colored link text.',
+        task: async(_, task): Promise<void> => {
+          task.output = `this behavior fixes ${link('https://github.com/listr2/listr2/issues/768', color.blueBright('issue #768'))}`
+          await delay(1000)
+        },
+        rendererOptions: { persistentOutput: true }
+      },
+      {
+        title: 'Emitting colored and styled output.',
+        task: async(_, task): Promise<void> => {
+          task.output = `${color.greenBright('colors')}, ${color.yellowBright('styles')} and ${color.underline('other formatting')} are preserved as well`
+          await delay(1000)
+        },
+        rendererOptions: { persistentOutput: true }
+      }
+    ],
+    { renderer: 'default' }
+  ).run()
+} catch(e: any) {
+  console.error(e)
+}

--- a/packages/listr2/src/utils/format/cleanse-ansi.constants.ts
+++ b/packages/listr2/src/utils/format/cleanse-ansi.constants.ts
@@ -1,3 +1,1 @@
-/* eslint-disable no-control-regex */
 export const CLEAR_LINE_REGEX = '(?:\\u001b|\\u009b)\\[[\\=><~/#&.:=?%@~_-]*[0-9]*[\\a-ln-tqyz=><~/#&.:=?%@~_-]+'
-export const BELL_REGEX = /\u0007/

--- a/packages/listr2/src/utils/format/cleanse-ansi.ts
+++ b/packages/listr2/src/utils/format/cleanse-ansi.ts
@@ -1,5 +1,5 @@
-import { BELL_REGEX, CLEAR_LINE_REGEX } from './cleanse-ansi.constants'
+import { CLEAR_LINE_REGEX } from './cleanse-ansi.constants'
 
 export function cleanseAnsi(chunk: string): string {
-  return String(chunk).replace(new RegExp(CLEAR_LINE_REGEX, 'gmi'), '').replace(new RegExp(BELL_REGEX, 'gmi'), '').trim()
+  return String(chunk).replace(new RegExp(CLEAR_LINE_REGEX, 'gmi'), '').trim()
 }

--- a/packages/listr2/tests/renderer/__snapshots__/osc8.e2e-spec.ts.snap
+++ b/packages/listr2/tests/renderer/__snapshots__/osc8.e2e-spec.ts.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`default renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-exit 1`] = `[]`;
+
+exports[`default renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stderr 1`] = `[]`;
+
+exports[`default renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stdout 1`] = `
+[
+  "[?25l",
+  "[2m◼[22m This task will output a hyperlink.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a hyperlink.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a hyperlink.
+  › ]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[2K[1A[2K[1A[2K[G[32m✔[39m This task will output a hyperlink.
+",
+  "[2K[1A[2K[G",
+  "[32m✔[39m This task will output a hyperlink.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-exit 1`] = `[]`;
+
+exports[`default renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stderr 1`] = `[]`;
+
+exports[`default renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stdout 1`] = `
+[
+  "[?25l",
+  "[2m◼[22m This task will output a colored hyperlink.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a colored hyperlink.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a colored hyperlink.
+  › [32m]8;;https://listr2.kilic.devlistr2]8;;[39m
+",
+  "[2K[1A[2K[1A[2K[G[32m✔[39m This task will output a colored hyperlink.
+",
+  "[2K[1A[2K[G",
+  "[32m✔[39m This task will output a colored hyperlink.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-exit 1`] = `[]`;
+
+exports[`default renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stderr 1`] = `[]`;
+
+exports[`default renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stdout 1`] = `
+[
+  "[?25l",
+  "[2m◼[22m This task will output a hyperlink next to a cursor code.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a hyperlink next to a cursor code.
+",
+  "[2K[1A[2K[G[33m❯[39m This task will output a hyperlink next to a cursor code.
+  › ]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[2K[1A[2K[1A[2K[G[32m✔[39m This task will output a hyperlink next to a cursor code.
+",
+  "[2K[1A[2K[G",
+  "[32m✔[39m This task will output a hyperlink next to a cursor code.
+",
+  "[?25h",
+]
+`;
+
+exports[`simple renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-exit 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stderr 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stdout 1`] = `
+[
+  "[33m❯[39m This task will output a hyperlink.
+",
+  "› ]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[32m✔[39m This task will output a hyperlink.
+",
+]
+`;
+
+exports[`simple renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-exit 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stderr 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stdout 1`] = `
+[
+  "[33m❯[39m This task will output a colored hyperlink.
+",
+  "› [32m]8;;https://listr2.kilic.devlistr2]8;;[39m
+",
+  "[32m✔[39m This task will output a colored hyperlink.
+",
+]
+`;
+
+exports[`simple renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-exit 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stderr 1`] = `[]`;
+
+exports[`simple renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stdout 1`] = `
+[
+  "[33m❯[39m This task will output a hyperlink next to a cursor code.
+",
+  "› [2K]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[32m✔[39m This task will output a hyperlink next to a cursor code.
+",
+]
+`;
+
+exports[`test renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-exit 1`] = `[]`;
+
+exports[`test renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stderr 1`] = `[]`;
+
+exports[`test renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink."]}}
+",
+  "{"event":"OUTPUT","data":"\\u001b]8;;https://listr2.kilic.dev\\u0007listr2\\u001b]8;;\\u0007","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink."]}}
+",
+  "{"event":"STATE","data":"COMPLETED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":true,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task will output a hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink."]}}
+",
+]
+`;
+
+exports[`test renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-exit 1`] = `[]`;
+
+exports[`test renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stderr 1`] = `[]`;
+
+exports[`test renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a colored hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a colored hyperlink."]}}
+",
+  "{"event":"OUTPUT","data":"\\u001b[32m\\u001b]8;;https://listr2.kilic.dev\\u0007listr2\\u001b]8;;\\u0007\\u001b[39m","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a colored hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a colored hyperlink."]}}
+",
+  "{"event":"STATE","data":"COMPLETED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":true,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task will output a colored hyperlink.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a colored hyperlink."]}}
+",
+]
+`;
+
+exports[`test renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-exit 1`] = `[]`;
+
+exports[`test renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stderr 1`] = `[]`;
+
+exports[`test renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a hyperlink next to a cursor code.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink next to a cursor code."]}}
+",
+  "{"event":"OUTPUT","data":"\\u001b[2K\\u001b]8;;https://listr2.kilic.dev\\u0007listr2\\u001b]8;;\\u0007","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will output a hyperlink next to a cursor code.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink next to a cursor code."]}}
+",
+  "{"event":"STATE","data":"COMPLETED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":true,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task will output a hyperlink next to a cursor code.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will output a hyperlink next to a cursor code."]}}
+",
+]
+`;
+
+exports[`verbose renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-exit 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stderr 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should preserve a bell-terminated osc-8 hyperlink: GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4-stdout 1`] = `
+[
+  "[33m[STARTED][39m This task will output a hyperlink.
+",
+  "[OUTPUT] ]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[32m[COMPLETED][39m This task will output a hyperlink.
+",
+]
+`;
+
+exports[`verbose renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-exit 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stderr 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should preserve a hyperlink wrapped in sgr colors: k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP-stdout 1`] = `
+[
+  "[33m[STARTED][39m This task will output a colored hyperlink.
+",
+  "[OUTPUT] [32m]8;;https://listr2.kilic.devlistr2]8;;[39m
+",
+  "[32m[COMPLETED][39m This task will output a colored hyperlink.
+",
+]
+`;
+
+exports[`verbose renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-exit 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stderr 1`] = `[]`;
+
+exports[`verbose renderer: osc-8 should strip an injected cursor code next to a hyperlink: GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky-stdout 1`] = `
+[
+  "[33m[STARTED][39m This task will output a hyperlink next to a cursor code.
+",
+  "[OUTPUT] [2K]8;;https://listr2.kilic.devlistr2]8;;
+",
+  "[32m[COMPLETED][39m This task will output a hyperlink next to a cursor code.
+",
+]
+`;

--- a/packages/listr2/tests/renderer/osc8.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/osc8.e2e-spec.ts
@@ -1,0 +1,147 @@
+import { Listr } from '@root'
+import type { MockProcessOutput, RendererSetup } from '@tests/utils'
+import { expectProcessOutputToMatchSnapshot, mockProcessOutput, unmockProcessOutput, RENDERER_SETUP } from '@tests/utils'
+import { cleanseAnsi } from '@utils'
+
+const ESC = '\x1b'
+const BEL = '\x07'
+const link = (uri: string, text: string): string => `${ESC}]8;;${uri}${BEL}${text}${ESC}]8;;${BEL}`
+
+describe.each<RendererSetup>(RENDERER_SETUP)('%s renderer: osc-8', (renderer, rendererOptions) => {
+  const output: MockProcessOutput = {} as MockProcessOutput
+
+  process.stdout.isTTY = true
+
+  beforeEach(async() => {
+    mockProcessOutput(output)
+  })
+
+  afterEach(async() => {
+    unmockProcessOutput(output)
+    jest.clearAllMocks()
+  })
+
+  function content(): string {
+    const written = output.stdout.mock.calls.map((call) => call[0] as string).join('')
+
+    if (renderer !== 'test') {
+      return written
+    }
+
+    return written
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((event) => event.event === 'OUTPUT')
+      .map((event) => event.data)
+      .join('')
+  }
+
+  // GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4
+  it('should preserve a bell-terminated osc-8 hyperlink', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will output a hyperlink.',
+          task: async(_, task): Promise<void> => {
+            task.output = link('https://listr2.kilic.dev', 'listr2')
+          }
+        }
+      ],
+      {
+        renderer,
+        rendererOptions
+      }
+    ).run()
+
+    const written = content()
+
+    expect(written).toContain(`${ESC}]8;;https://listr2.kilic.dev`)
+    expect(written).toContain(`${ESC}]8;;${BEL}`)
+
+    expectProcessOutputToMatchSnapshot(output, 'GuVrX0HJ82h7aCSBxfdRJm3LbCJ1scU4')
+  })
+
+  // k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP
+  it('should preserve a hyperlink wrapped in sgr colors', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will output a colored hyperlink.',
+          task: async(_, task): Promise<void> => {
+            task.output = `${ESC}[32m${link('https://listr2.kilic.dev', 'listr2')}${ESC}[39m`
+          }
+        }
+      ],
+      {
+        renderer,
+        rendererOptions
+      }
+    ).run()
+
+    const written = content()
+
+    expect(written).toContain(`${ESC}]8;;https://listr2.kilic.dev`)
+    expect(written).toContain(`${ESC}]8;;${BEL}`)
+    expect(written).toContain(`${ESC}[32m`)
+    expect(written).toContain(`${ESC}[39m`)
+
+    expectProcessOutputToMatchSnapshot(output, 'k9Fj0ZFCmcutR9qKoIYBHDNGAzhDAjWP')
+  })
+
+  // GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky
+  it('should strip an injected cursor code next to a hyperlink', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will output a hyperlink next to a cursor code.',
+          task: async(_, task): Promise<void> => {
+            task.output = `${ESC}[2K${link('https://listr2.kilic.dev', 'listr2')}`
+          }
+        }
+      ],
+      {
+        renderer,
+        rendererOptions
+      }
+    ).run()
+
+    const written = content()
+
+    expect(written).toContain(`${ESC}]8;;https://listr2.kilic.dev`)
+    expect(written).toContain(`${ESC}]8;;${BEL}`)
+
+    // only the default renderer routes task.output through cleanseAnsi before printing; the others print output verbatim
+    if (renderer === 'default') {
+      expect(written).not.toContain(`${ESC}[2K${ESC}]8;;`)
+    }
+
+    expectProcessOutputToMatchSnapshot(output, 'GIuPLb3vSEkIj8naBxgBbLow2xt0ZGky')
+  })
+})
+
+describe('cleanseAnsi', () => {
+  it('preserves an esc-backslash terminated hyperlink untouched', () => {
+    const input = `${ESC}]8;;https://x${ESC}\\link${ESC}]8;;${ESC}\\`
+
+    expect(cleanseAnsi(input)).toBe(input)
+  })
+
+  it('preserves two adjacent hyperlinks', () => {
+    const input = `${link('https://a', 'A')}${link('https://b', 'B')}`
+
+    const result = cleanseAnsi(input)
+
+    expect(result).toBe(input)
+  })
+
+  it('preserves a standalone bell', () => {
+    expect(cleanseAnsi(`a${BEL}b`)).toBe(`a${BEL}b`)
+  })
+
+  it('preserves sgr codes and strips csi cursor codes', () => {
+    const result = cleanseAnsi(`${ESC}[32mred${ESC}[39m${ESC}[2K`)
+
+    expect(result).toBe(`${ESC}[32mred${ESC}[39m`)
+  })
+})


### PR DESCRIPTION
### Open Issue

Closes #768 — Linear `K-705`.

### Preflight

- [x] Create an issue for a preliminary discussion or link the existing issue.
- [x] Follow guidelines enforced by `git-hooks` of linting, tests, and commit convention, which is [Angular conventional commits](https://www.conventionalcommits.org/).
- [x] Add tests whenever or if possible.
- [x] Update the documentation.

---

## Summary

`cleanseAnsi` stripped every bell (`U+0007`), which is a legal OSC-8 string terminator, so bell-terminated terminal hyperlinks in `task.output` were destroyed (#768). It now strips only the cursor/erase control codes that would disrupt the line-based rendering and passes everything else the user emits — colors, OSC-8 hyperlinks and bells — through untouched.

## Changes

- `cleanseAnsi` now only strips `CLEAR_LINE_REGEX` (cursor movement / erase / scroll); dropped the wholesale bell strip and the now-unused `BELL_REGEX`.
- Verified that bare bells and complete OSC-8 sequences are zero-width in `wrap-ansi` / `cli-truncate`, so preserving them does not shift wrapping, truncation or frame clearing.
- Added `tests/renderer/osc8.e2e-spec.ts` — the first coverage for `cleanseAnsi`.
- Documented under `## Features` in `docs/migration/v11.md`, and added a runnable, human-testable `examples/task-output-formatting.example.ts` (persistent OSC-8 hyperlinks + colored output).

## Notes

Targets `beta` (the v11 line). Non-breaking behavior change — 445 pre-existing core snapshots unchanged.