### PR TITLE
fix(lib): show the cursor during interactive prompts

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -13,3 +13,4 @@ order: 60
 - The _Listr_ option `collectErrors` is now a `boolean` instead of `false | 'minimal' | 'full'`. Use `true` for the previous `'minimal'` behavior, the `'full'` mode has been removed.
 - `ListrError` no longer clones the context in to the error instance and its `ctx` property has been removed. Only the `error`, its `type` and the `path` of the failed task are collected.
 - Dropped the `rfdc` dependency and removed the `cloneObject` utility from the exports, which were only used by the removed `'full'` error collection mode.
+- The cursor is now visible while an interactive prompt is waiting for input and hidden again for the rendered output afterwards; it is always restored when _Listr_ ends, including on cancellation or interruption. Previously the cursor stayed hidden throughout a prompt. This changes the rendered output of prompts.

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -90,11 +90,12 @@ export class DefaultRenderer implements ListrRenderer {
     const { default: truncate } = await import('cli-truncate')
     const { default: wrap } = await import('wrap-ansi')
 
-    this.updater = createLogUpdate(this.logger.process.stdout)
+    this.updater = createLogUpdate(this.logger.process.stdout, { showCursor: true })
     this.truncate = truncate
     this.wrap = wrap
 
     this.logger.process.hijack()
+    this.logger.process.hideCursor()
 
     /* istanbul ignore if */
     if (!this.options?.lazy) {
@@ -303,10 +304,14 @@ export class DefaultRenderer implements ListrRenderer {
               this.prompt = null
               this.activePrompt = null
               task.off(ListrTaskEventType.PROMPT)
+
+              this.logger.process.hideCursor()
             }
           })
 
           this.activePrompt = task.id
+
+          this.logger.process.showCursor()
         }
       }
 

--- a/packages/listr2/src/renderer/simple/renderer.ts
+++ b/packages/listr2/src/renderer/simple/renderer.ts
@@ -48,7 +48,9 @@ export class SimpleRenderer implements ListrRenderer {
     }
   }
 
-  public end(): void {}
+  public end(): void {
+    this.logger.process.release()
+  }
 
   public render(): void {
     this.renderer(this.tasks)

--- a/packages/listr2/src/utils/process-output/process-output.ts
+++ b/packages/listr2/src/utils/process-output/process-output.ts
@@ -41,17 +41,28 @@ export class ProcessOutput {
     return this.stream.stderr.out
   }
 
+  public hideCursor(): void {
+    this.stream.stdout.write(ANSI_ESCAPE_CODES.CURSOR_HIDE)
+  }
+
+  public showCursor(): void {
+    this.stream.stdout.write(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+  }
+
   public hijack(): void {
     if (this.active) {
       throw new Error('ProcessOutput has been already hijacked!')
     }
 
-    this.stream.stdout.write(ANSI_ESCAPE_CODES.CURSOR_HIDE)
     Object.values(this.stream).forEach((stream) => stream.hijack())
     this.active = true
   }
 
   public release(): void {
+    if (!this.active) {
+      return
+    }
+
     // not the most performant of functions, since creating a lots of memory
     // maybe refactor this sometime, but shouldnt be concern since we do not expect
     // huge number of outputs being buffered
@@ -80,7 +91,7 @@ export class ProcessOutput {
       })
     }
 
-    this.stream.stdout.write(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+    this.showCursor()
 
     this.active = false
   }

--- a/packages/listr2/tests/process-output.e2e-spec.ts
+++ b/packages/listr2/tests/process-output.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { ANSI_ESCAPE_CODES } from '@constants'
+import type { MockProcessOutput } from '@tests/utils'
+import { mockProcessOutput, unmockProcessOutput } from '@tests/utils'
+import { ProcessOutput } from '@utils'
+
+describe('process-output: cursor', () => {
+  const output: MockProcessOutput = {} as MockProcessOutput
+
+  beforeEach(() => {
+    mockProcessOutput(output)
+  })
+
+  afterEach(() => {
+    unmockProcessOutput(output)
+    jest.clearAllMocks()
+  })
+
+  it('should hide the cursor on demand', () => {
+    new ProcessOutput().hideCursor()
+
+    expect(output.stdout).toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_HIDE)
+  })
+
+  it('should show the cursor on demand', () => {
+    new ProcessOutput().showCursor()
+
+    expect(output.stdout).toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+  })
+
+  it('should not touch the cursor when hijacking, so the owner controls visibility', () => {
+    new ProcessOutput().hijack()
+
+    expect(output.stdout).not.toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_HIDE)
+    expect(output.stdout).not.toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+  })
+
+  it('should restore the cursor when releasing an active hijack', () => {
+    const process = new ProcessOutput()
+
+    process.hijack()
+    process.release()
+
+    expect(output.stdout).toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+  })
+
+  it('should not restore the cursor when releasing without an active hijack', () => {
+    new ProcessOutput().release()
+
+    expect(output.stdout).not.toHaveBeenCalledWith(ANSI_ESCAPE_CODES.CURSOR_SHOW)
+  })
+})


### PR DESCRIPTION
### Open Issue

Linear `K-709`. No public GitHub issue — identified from snapshot analysis of the prompt render.

### Preflight

- [x] Create an issue for a preliminary discussion or link the existing issue.
- [x] Follow guidelines enforced by `git-hooks` of linting, tests, and commit convention, which is [Angular conventional commits](https://www.conventionalcommits.org/).
- [x] Add tests whenever or if possible.
- [x] Update the documentation.

---

## Summary

The terminal cursor stayed hidden while an interactive prompt was waiting for input, so users couldn't see what they were typing; it was also not reliably restored on early termination. This moves cursor ownership entirely to `ProcessOutput` and drives visibility from the renderers.

## Changes

- `ProcessOutput` gains `hideCursor()` / `showCursor()` helpers and is now the sole cursor owner. `hijack()` no longer hides the cursor; `release()` restores it, guarded so it is a no-op when nothing was hijacked.
- **Default renderer:** `log-update` is created with `{ showCursor: true }` so it never touches the cursor; the renderer hides the cursor after hijacking, shows it while a prompt is active, and hides it again for the rendered output once the prompt completes.
- **Simple renderer:** `end()` now releases the process output, restoring the cursor if a prompt was interrupted mid-flight.
- Cursor is always restored on termination — normal end, error exit, and SIGINT all route through `release()`.

## Tests

- New `tests/process-output.e2e-spec.ts` locking the cursor contract (hide/show on demand, `hijack()` does not touch the cursor, `release()` restores only when active).
- Regenerated enquirer/inquirer prompt snapshots now capture the cursor show/hide sequences around prompts — end-to-end coverage.

## Notes

Targets `beta` (the v11 line). Breaking byte-stream change — prompt output now emits cursor sequences — documented in `docs/migration/v11.md`. Non-prompt render behavior is unchanged (445 core snapshots unchanged).