### PR TITLE
[Feat]: run rollback on interruption and add a cancelled task state

### DIFF
--- a/docs/listr/interruption.md
+++ b/docs/listr/interruption.md
@@ -1,0 +1,71 @@
+---
+title: Interruption
+order: 30
+---
+
+# {{ $frontmatter.title }}
+
+While a run is in progress, _Listr_ registers a `SIGINT` handler so it can be interrupted gracefully with `Ctrl+C` instead of the process being killed outright.
+
+<Version version="v11.0.0" /><GithubIssue :issue="769" />
+
+<!-- more -->
+
+::: info Example
+
+You can find the related example [here](https://github.com/listr2/listr2/tree/master/examples/interruption.example.ts).
+
+:::
+
+## Behavior
+
+When a run is interrupted with `Ctrl+C` (`SIGINT`):
+
+- Every in-flight task that defines a [`rollback`](/task/rollback.html) is rolled back before the process exits, reusing the same rollback mechanism as a normal failure.
+- Nested rollbacks run from the innermost task outwards, so a subtask always rolls back before its parent.
+- Tasks without a `rollback`, as well as any tasks that had not started yet, are marked with the `cancelled` state, shown as a `⊘` in the default renderer. This is distinct from `failed`, so an interrupted run is not mistaken for one that errored.
+- The process exits with code `127`, but only after every in-flight rollback has settled.
+
+## The signal mechanism
+
+Interruption can not cancel an already-running _Promise_, so the original task function keeps executing in the background until it settles on its own while its `rollback` runs. To cancel your own asynchronous work cooperatively, use the `AbortSignal` exposed as `task.signal`, which aborts as soon as the run is interrupted.
+
+```typescript
+{
+  title: 'Downloading a large file.',
+  task: async (ctx, task): Promise<void> => {
+    await fetch('https://listr2.kilic.dev', { signal: task.signal })
+  },
+  rollback: async (ctx, task): Promise<void> => {
+    // remove the partially downloaded file
+  }
+}
+```
+
+`task.signal` is a standard [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) and can be handed to anything that accepts one, like `fetch`, `node:child_process` or timers, or subscribed to directly through `task.signal.addEventListener('abort', ...)`.
+
+## Triggering it programmatically
+
+The run can be interrupted from your own code, which is useful when a task needs to abort the whole run — and cancel or roll back its siblings — on some condition. Call `task.cancel()` from inside a task, or `listr.cancel()` on the instance you are running.
+
+```typescript
+{
+  title: 'Guard the deployment.',
+  task: async (ctx, task): Promise<void> => {
+    if (await detectedFatalCondition()) {
+      // cancel every other in-flight task, run their rollbacks, then exit with 127
+      task.cancel()
+    }
+  }
+}
+```
+
+`cancel()` follows the exact same path as pressing `Ctrl+C` — the other in-flight tasks roll back or are marked as `cancelled`, and the process exits with `127` once every rollback has settled — but without going through an operating-system signal, so it works regardless of the `registerSignalListeners` option. Sending `SIGINT` yourself with `process.kill(process.pid, 'SIGINT')` has the same effect.
+
+::: warning An interruption always terminates the process with `127`, whether it comes from `Ctrl+C` or `cancel()`. :::
+
+## Disabling the signal handlers
+
+The `SIGINT` handling, and therefore the rollback-on-interruption behavior, can be turned off through the `registerSignalListeners` _Listr_ option.
+
+::: warning When `registerSignalListeners` is set to `false`, `Ctrl+C` terminates the process immediately without running any rollback or cleanup. :::

--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -13,7 +13,11 @@ order: 60
 - The _Listr_ option `collectErrors` is now a `boolean` instead of `false | 'minimal' | 'full'`. Use `true` for the previous `'minimal'` behavior, the `'full'` mode has been removed.
 - `ListrError` no longer clones the context in to the error instance and its `ctx` property has been removed. Only the `error`, its `type` and the `path` of the failed task are collected.
 - Dropped the `rfdc` dependency and removed the `cloneObject` utility from the exports, which were only used by the removed `'full'` error collection mode.
+- Interrupting a run with `Ctrl+C` (`SIGINT`) now runs the `rollback` of any in-flight task that defines one and defers the `exit(127)` until every in-flight rollback has settled, instead of marking the pending tasks as failed and exiting synchronously. <GithubIssue :issue="769" />
+- Added a new `ListrTaskState.CANCELLED` state, with an `task.isCancelled()` helper and a `⊘` icon in the built-in renderers. Tasks stopped by an interruption that do not roll back — as well as any tasks that had not started — are now marked as `CANCELLED` instead of `FAILED`. Custom renderers that switch on the task state should handle it. <GithubIssue :issue="769" />
 
 ## Features
 
 - [x] preserve OSC-8 hyperlinks, bells and other formatting in the task output, only stripping the cursor and erase codes that would disrupt the rendering <GithubIssue :issue="768" />
+- [x] expose the run's `AbortSignal` on the task wrapper as `task.signal`, so task functions can cooperatively cancel their own asynchronous work like `fetch`, child processes or timers when the run is interrupted <GithubIssue :issue="769" />
+- [x] add `listr.cancel()` and `task.cancel()` to interrupt a run programmatically without an operating-system signal, rolling back or cancelling the in-flight tasks the same way `Ctrl+C` does <GithubIssue :issue="769" />

--- a/docs/migration/v7.md
+++ b/docs/migration/v7.md
@@ -17,7 +17,7 @@ If you encounter any more of the breaking changes, please feel free to contribut
 
 - The repository has been converted to a monorepo and some parts of it has been broken down in to smaller packages.
 - Since this is still a hybrid module transpiled for `cjs`/`esm` imports, with the new changes for Typescript `v5.0.0`+ should be fixed.
-- _Listr_ options `disableColor` and `forceColor` have been removed since they were not working as intended. Users are encouraged to use underlying environment variables for [colorrette](https://www.npmjs.com/package/colorette), which are `FORCE_COLOR` and `NO_COLOR`.
+- _Listr_ options `disableColor` and `forceColor` have been removed since they were not working as intended. Users are encouraged to use underlying environment variables for [colorette](https://www.npmjs.com/package/colorette), which are `FORCE_COLOR` and `NO_COLOR`.
 - Environment variable `LISTR_DISABLE_COLOR` has been removed in favor of using the underlying library's `NO_COLOR` option instead to have consistency with other libraries.
 - _Task_ `options` property, which is used for per-renderer task options has been deprecated in favor of `rendererOptions` and `fallbackRendererOptions` to define the per-renderer task options. This change has been done to properly inject circular types, as well as, pass task options to fallback renderer.
 - _Manager_ is now its own seperate package that can be installed on demand through `@listr2/manager`.

--- a/docs/renderer/fallback-condition.md
+++ b/docs/renderer/fallback-condition.md
@@ -26,7 +26,7 @@ A function that returns a boolean , or directly a boolean can be passed to _List
 
 ### Coloring
 
-[`colorette`](https://www.npmjs.com/package/colorette) is used as the underlying coloring library. Colors are disabled automatically by underlying the library whenever it is detected as not supported.
+Node's built-in [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) from `node:util` is used as the underlying coloring mechanism. Colors are disabled automatically whenever it is detected as not supported.
 
 - You can set the environment variable `FORCE_COLOR=1` to force colors.
 - You can set the environment variable `NO_COLOR=1` to disable colors completely even though your environment supports it. This is very useful for tests.

--- a/docs/task/rollback.md
+++ b/docs/task/rollback.md
@@ -29,6 +29,10 @@ You can find the related examples [here](https://github.com/listr2/listr2/tree/m
 
 Rollback, when it fails by default, throws an exception and stops the execution of the upcoming tasks. But this can be overwritten by `{ exitAfterRollback: false }` option. This is the main Listr option that acts independently of `exitOnError` since failing the rollback might have worse consequences.
 
+## Interruption
+
+Besides task failures, `rollback` also runs when a run is interrupted with `Ctrl+C`. See [Interruption](/listr/interruption.html) for how interruption behaves and how to cancel your own work cooperatively through `task.signal`. <GithubIssue :issue="769" />
+
 ## Renderer
 
 ### _DefaultRenderer_

--- a/examples/interruption.example.ts
+++ b/examples/interruption.example.ts
@@ -1,0 +1,45 @@
+import { delay, Listr } from 'listr2'
+
+try {
+  await new Listr(
+    [
+      {
+        title: 'Provisioning the servers.',
+        task: async(): Promise<void> => {
+          await delay(5000)
+        },
+        rollback: async(_, task): Promise<void> => {
+          task.title = 'Tearing the servers back down.'
+
+          await delay(1000)
+        }
+      },
+      {
+        title: 'Running the health checks.',
+        task: async(_, task): Promise<void> => {
+          await delay(1000)
+
+          task.output = 'Health check failed, cancelling the run.'
+
+          task.cancel()
+
+          await delay(5000)
+        }
+      },
+      {
+        title: 'Deploying the application.',
+        task: async(): Promise<void> => {
+          await delay(5000)
+        },
+        rollback: async(_, task): Promise<void> => {
+          task.title = 'Rolling back the deployment.'
+
+          await delay(1000)
+        }
+      }
+    ],
+    { concurrent: true, renderer: 'default' }
+  ).run()
+} catch(e: any) {
+  console.error(e)
+}

--- a/packages/listr2/src/constants/listr-task-state.constants.ts
+++ b/packages/listr2/src/constants/listr-task-state.constants.ts
@@ -27,5 +27,7 @@ export enum ListrTaskState {
   /** Task has successfully processed the prompt. */
   PROMPT_COMPLETED = 'PROMPT_COMPLETED',
   /** Task has failed to process the prompt. */
-  PROMPT_FAILED = 'PROMPT_FAILED'
+  PROMPT_FAILED = 'PROMPT_FAILED',
+  /** Task has been cancelled by an interruption before it could finish. */
+  CANCELLED = 'CANCELLED'
 }

--- a/packages/listr2/src/lib/task-wrapper.ts
+++ b/packages/listr2/src/lib/task-wrapper.ts
@@ -57,6 +57,24 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory, FallbackRen
   }
 
   /**
+   * The `AbortSignal` for the current run, aborted when the run is interrupted (e.g. `SIGINT`).
+   * Wire it into your own async work (`fetch`, child processes, timers) to cancel cooperatively.
+   *
+   * @see {@link https://listr2.kilic.dev/task/rollback.html}
+   */
+  get signal(): AbortSignal {
+    return this.task.listr.signal
+  }
+
+  /**
+   * Interrupt the whole run programmatically, as if it received a `SIGINT`.
+   * The other in-flight tasks roll back or are marked as cancelled, then the process exits with `127`.
+   */
+  public cancel(): void {
+    this.task.listr.cancel()
+  }
+
+  /**
    * Creates a new set of Listr subtasks.
    *
    * @see {@link https://listr2.kilic.dev/task/subtasks.html}

--- a/packages/listr2/src/lib/task.ts
+++ b/packages/listr2/src/lib/task.ts
@@ -171,7 +171,7 @@ export class Task<
 
   /** Returns whether this task is finalized in someform. */
   public hasFinalized(): boolean {
-    return this.isCompleted() || this.hasFailed() || this.isSkipped() || this.hasRolledBack()
+    return this.isCompleted() || this.hasFailed() || this.isSkipped() || this.hasRolledBack() || this.isCancelled()
   }
 
   /** Returns whether this task is in progress. */
@@ -197,6 +197,11 @@ export class Task<
   /** Returns whether this task has been failed. */
   public hasFailed(): boolean {
     return this.state === ListrTaskState.FAILED
+  }
+
+  /** Returns whether this task has been cancelled by an interruption. */
+  public isCancelled(): boolean {
+    return this.state === ListrTaskState.CANCELLED
   }
 
   /** Returns whether this task has an active rollback task going on. */
@@ -341,11 +346,17 @@ export class Task<
 
       for (let retries = 1; retries <= retryCount; retries++) {
         try {
-          // handle the results
-          await handleResult(this.taskFn(context, wrapper))
+          // race the task against interruption so SIGINT rejects into the rollback path below; whenInterrupted() only
+          // rejects leaf tasks, so a task that has spawned subtasks unwinds through its children (child before parent)
+          await Promise.race([handleResult(this.taskFn(context, wrapper)), this.whenInterrupted()])
 
           break
         } catch(err: any) {
+          // never retry an interrupted task
+          if (this.listr.signal.aborted) {
+            throw err
+          }
+
           if (retries !== retryCount) {
             this.retry = { count: retries, error: err }
             this.message$ = { retry: this.retry }
@@ -403,6 +414,13 @@ export class Task<
           throw error
         }
       } else {
+        // interrupted: mark as cancelled and bail quietly, without surfacing a per-task "Interrupted." message
+        if (this.listr.signal.aborted) {
+          this.state$ = ListrTaskState.CANCELLED
+
+          throw error
+        }
+
         // mark task as failed
         this.state$ = ListrTaskState.FAILED
 
@@ -427,5 +445,24 @@ export class Task<
     this.emit(ListrTaskEventType.CLOSED)
     this.listr.events.emit(ListrEventType.SHOULD_REFRESH_RENDER)
     this.complete()
+  }
+
+  private whenInterrupted(): Promise<never> {
+    return new Promise((_, reject) => {
+      const onAbort = (): void => {
+        // only leaf tasks reject on abort; a task that has spawned subtasks rejects naturally once a child rejects
+        if (!this.hasSubtasks()) {
+          reject(new Error('Interrupted.'))
+        }
+      }
+
+      if (this.listr.signal.aborted) {
+        onAbort()
+
+        return
+      }
+
+      this.listr.signal.addEventListener('abort', onAbort, { once: true })
+    })
   }
 }

--- a/packages/listr2/src/listr.ts
+++ b/packages/listr2/src/listr.ts
@@ -1,3 +1,5 @@
+import { setMaxListeners } from 'node:events'
+
 import { ListrRendererSelection, ListrEnvironmentVariables, ListrTaskState } from '@constants'
 import type {
   ListrBaseClassOptions,
@@ -35,9 +37,15 @@ export class Listr<
   public rendererClassOptions: ListrGetRendererOptions<ListrGetRendererClassFromValue<Renderer> | ListrGetRendererClassFromValue<FallbackRenderer>>
   public rendererSelection: ListrRendererSelection
   public boundSignalHandler: () => void
+  public signal: AbortSignal
 
   private concurrency: Concurrency
   private renderer: ListrRenderer
+  private abortController: AbortController
+  // promises of the tasks that actually started (never the queued ones, whose `Concurrency` promises never settle
+  // after a `queue.clear()`); awaited on interrupt so every in-flight rollback settles — and, via the sub-Listr
+  // promise chain, children before their parent — before the root exits
+  private startedTasks: Promise<void>[] = []
 
   constructor(
     public task:
@@ -80,6 +88,16 @@ export class Listr<
       this.events = new ListrEventManager()
     }
 
+    // share a single AbortController down the run tree, the same way events are shared
+    if (this.parentTask?.listr.abortController instanceof AbortController) {
+      this.abortController = this.parentTask.listr.abortController
+    } else {
+      this.abortController = new AbortController()
+      setMaxListeners(0, this.abortController.signal)
+    }
+
+    this.signal = this.abortController.signal
+
     /* istanbul ignore if */
     if (this.options?.forceTTY || process.env[ListrEnvironmentVariables.FORCE_TTY]) {
       process.stdout.isTTY = true
@@ -109,11 +127,13 @@ export class Listr<
     /* istanbul ignore next */
     this.add(task ?? [])
 
-    // Graceful interrupt for render cleanup
+    // Register a persistent SIGINT listener on the root only. It stays until removeSignalHandler(), so it survives the
+    // SIGINT re-raise that signal-exit (pulled in by log-update's cursor handling) fires, giving the async rollbacks
+    // time to settle before run() exits — a `once` listener would be gone by the re-raise and the process would die.
     /* istanbul ignore if */
-    if (this.options.registerSignalListeners) {
+    if (this.options.registerSignalListeners && this.isRoot()) {
       this.boundSignalHandler = this.signalHandler.bind(this)
-      process.once('SIGINT', this.boundSignalHandler).setMaxListeners(0)
+      process.on('SIGINT', this.boundSignalHandler).setMaxListeners(0)
     }
   }
 
@@ -156,27 +176,67 @@ export class Listr<
     // create a new context
     this.ctx = this.options?.ctx ?? context ?? ({} as Ctx)
 
+    let error: any
+    let failed = false
+
     try {
       // check if the items are enabled
       await Promise.all(this.tasks.map((task) => task.check(this.ctx)))
       // run tasks
       await Promise.all(this.tasks.map((task) => this.concurrency.add(() => this.runTask(task))))
-
-      this.renderer.end()
-
-      this.removeSignalHandler()
     } catch(err: any) {
-      if (this.options.exitOnError !== false) {
-        this.renderer.end(err)
+      failed = true
+      error = err
+    }
+
+    // interrupted: let every task this list started settle its rollback before exiting or propagating, regardless of
+    // exitOnError/exitAfterRollback — a swallowed failure must still exit, and children must settle before their parent
+    if (this.signal.aborted) {
+      await Promise.allSettled(this.startedTasks)
+
+      if (this.isRoot()) {
+        // cancel anything left unstarted or in progress so the renderer marks the whole tree as interrupted
+        this.cancelUnfinishedTasks()
+
+        this.renderer.end()
 
         this.removeSignalHandler()
 
-        // Do not exit when explicitly set to `false`
-        throw err
+        process.exit(127)
+
+        // only reached when process.exit is stubbed, e.g. under test
+        return this.ctx
       }
+
+      // sub-Listr: propagate so the parent task only rolls back after all of its children have settled
+      throw error ?? new Error('Interrupted.')
+    }
+
+    // Do not exit when explicitly set to `false`
+    if (failed && this.options.exitOnError !== false) {
+      this.renderer.end(error)
+
+      this.removeSignalHandler()
+
+      throw error
+    }
+
+    if (!failed) {
+      this.renderer.end()
+
+      this.removeSignalHandler()
     }
 
     return this.ctx
+  }
+
+  /**
+   * Interrupt the running task list programmatically, as if it received a `SIGINT`.
+   *
+   * In-flight tasks roll back or are marked as cancelled and the process exits with `127`.
+   */
+  public cancel(): void {
+    this.abortController.abort()
   }
 
   private generate(
@@ -186,8 +246,7 @@ export class Listr<
 
     return tasks.map((task) => {
       let rendererTaskOptions:
-        | ListrGetRendererTaskOptions<ListrGetRendererClassFromValue<Renderer>>
-        | ListrGetRendererTaskOptions<ListrGetRendererClassFromValue<FallbackRenderer>>
+        ListrGetRendererTaskOptions<ListrGetRendererClassFromValue<Renderer>> | ListrGetRendererTaskOptions<ListrGetRendererClassFromValue<FallbackRenderer>>
 
       if (this.rendererSelection === ListrRendererSelection.PRIMARY) {
         rendererTaskOptions = task.rendererOptions
@@ -210,27 +269,34 @@ export class Listr<
       return
     }
 
-    return new TaskWrapper(task).run(this.ctx)
+    const promise = new TaskWrapper(task).run(this.ctx)
+
+    this.startedTasks.push(promise)
+
+    return promise
   }
 
   private signalHandler(): void {
-    this.tasks?.forEach(async(task) => {
-      if (task.isPending()) {
-        task.state$ = ListrTaskState.FAILED
-      }
-    })
-
-    // only the parent task shall exit
-    if (this.isRoot()) {
-      this.renderer?.end(new Error('Interrupted.'))
-
-      process.exit(127)
-    }
+    // interrupt the run tree: in-flight leaf tasks reject into their rollback path, then run() exits once settled
+    this.abortController.abort()
   }
 
   private removeSignalHandler(): void {
     if (this.boundSignalHandler) {
       process.removeListener('SIGINT', this.boundSignalHandler)
+    }
+  }
+
+  private cancelUnfinishedTasks(tasks: Task<Ctx, ListrGetRendererClassFromValue<Renderer>, ListrGetRendererClassFromValue<FallbackRenderer>>[] = this.tasks): void {
+    for (const task of tasks) {
+      if (task.hasSubtasks()) {
+        this.cancelUnfinishedTasks(task.subtasks)
+      }
+
+      // `!== false` is deliberate: a task interrupted before its check() ran has `enabled === undefined` and should still cancel
+      if (task.isEnabled() !== false && !task.hasFinalized()) {
+        task.state$ = ListrTaskState.CANCELLED
+      }
     }
   }
 }

--- a/packages/listr2/src/renderer/default/renderer.constants.ts
+++ b/packages/listr2/src/renderer/default/renderer.constants.ts
@@ -16,7 +16,8 @@ export enum ListrDefaultRendererLogLevels {
   FAILED = 'FAILED',
   FAILED_WITH_FAILED_SUBTASKS = 'FAILED_WITH_SUBTASKS',
   WAITING = 'WAITING',
-  PAUSED = 'PAUSED'
+  PAUSED = 'PAUSED',
+  CANCELLED = 'CANCELLED'
 }
 
 export const LISTR_DEFAULT_RENDERER_STYLE: ListrLoggerStyleMap<ListrDefaultRendererLogLevels> = {
@@ -35,7 +36,8 @@ export const LISTR_DEFAULT_RENDERER_STYLE: ListrLoggerStyleMap<ListrDefaultRende
     [ListrDefaultRendererLogLevels.FAILED]: figures.cross,
     [ListrDefaultRendererLogLevels.FAILED_WITH_FAILED_SUBTASKS]: figures.pointer,
     [ListrDefaultRendererLogLevels.WAITING]: figures.squareSmallFilled,
-    [ListrDefaultRendererLogLevels.PAUSED]: figures.squareSmallFilled
+    [ListrDefaultRendererLogLevels.PAUSED]: figures.squareSmallFilled,
+    [ListrDefaultRendererLogLevels.CANCELLED]: figures.circleSlash
   },
   color: {
     [ListrDefaultRendererLogLevels.SKIPPED_WITH_COLLAPSE]: color.yellow,
@@ -50,6 +52,7 @@ export const LISTR_DEFAULT_RENDERER_STYLE: ListrLoggerStyleMap<ListrDefaultRende
     [ListrDefaultRendererLogLevels.FAILED]: color.red,
     [ListrDefaultRendererLogLevels.FAILED_WITH_FAILED_SUBTASKS]: color.red,
     [ListrDefaultRendererLogLevels.WAITING]: color.dim,
-    [ListrDefaultRendererLogLevels.PAUSED]: color.yellowBright
+    [ListrDefaultRendererLogLevels.PAUSED]: color.yellowBright,
+    [ListrDefaultRendererLogLevels.CANCELLED]: color.red
   }
 }

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -206,6 +206,8 @@ export class DefaultRenderer implements ListrRenderer {
       return this.logger.icon(ListrDefaultRendererLogLevels.ROLLED_BACK)
     } else if (task.hasFailed()) {
       return this.logger.icon(ListrDefaultRendererLogLevels.FAILED)
+    } else if (task.isCancelled()) {
+      return this.logger.icon(ListrDefaultRendererLogLevels.CANCELLED)
     } else if (task.isPaused()) {
       return this.logger.icon(ListrDefaultRendererLogLevels.PAUSED)
     }
@@ -312,7 +314,12 @@ export class DefaultRenderer implements ListrRenderer {
 
       // Current Task Title
       if (task.hasTitle()) {
-        if (!(tasks.some((task) => task.hasFailed()) && !task.hasFailed() && task.options.exitOnError !== false && !(task.isCompleted() || task.isSkipped()))) {
+        if (!(
+          tasks.some((task) => task.hasFailed()) &&
+          !task.hasFailed() &&
+          task.options.exitOnError !== false &&
+          !(task.isCompleted() || task.isSkipped() || task.isCancelled())
+        )) {
           // if task is skipped
           if (task.hasFailed() && rendererOptions.collapseErrors) {
             // current task title and skip change the title
@@ -409,7 +416,9 @@ export class DefaultRenderer implements ListrRenderer {
           // if any of the subtasks has failed
           task.subtasks.some((subtask) => subtask.hasFailed()) ||
           // if any of the subtasks rolled back
-          task.subtasks.some((subtask) => subtask.hasRolledBack()))
+          task.subtasks.some((subtask) => subtask.hasRolledBack()) ||
+          // if any of the subtasks was cancelled
+          task.subtasks.some((subtask) => subtask.isCancelled()))
       ) {
         // set level
         const subtaskLevel = !task.hasTitle() ? level : level + 1

--- a/packages/listr2/src/renderer/simple/renderer.ts
+++ b/packages/listr2/src/renderer/simple/renderer.ts
@@ -100,6 +100,8 @@ export class SimpleRenderer implements ListrRenderer {
           task.off(ListrTaskEventType.PROMPT)
 
           this.logger.process.release()
+        } else if (state === ListrTaskState.CANCELLED) {
+          this.logger.log(ListrLogLevels.CANCELLED, task.title)
         }
       })
 

--- a/packages/listr2/src/renderer/verbose/renderer.ts
+++ b/packages/listr2/src/renderer/verbose/renderer.ts
@@ -90,6 +90,8 @@ export class VerboseRenderer implements ListrRenderer {
               }
             }
           )
+        } else if (state === ListrTaskState.CANCELLED) {
+          this.logger.log(ListrLogLevels.CANCELLED, task.title)
         }
       })
 

--- a/packages/listr2/src/utils/format/figures.ts
+++ b/packages/listr2/src/utils/format/figures.ts
@@ -10,7 +10,8 @@ const FIGURES_MAIN = {
   checkboxOn: '☒',
   arrowLeft: '←',
   squareSmallFilled: '◼',
-  pointerSmall: '›'
+  pointerSmall: '›',
+  circleSlash: '⊘'
 }
 
 const FIGURES_FALLBACK = {
@@ -20,7 +21,8 @@ const FIGURES_FALLBACK = {
   tick: '√',
   pointer: '>',
   checkboxOn: '[×]',
-  squareSmallFilled: '■'
+  squareSmallFilled: '■',
+  circleSlash: 'ø'
 }
 
 export type Figures = typeof FIGURES_MAIN

--- a/packages/listr2/src/utils/logger/logger.constants.ts
+++ b/packages/listr2/src/utils/logger/logger.constants.ts
@@ -12,7 +12,8 @@ export enum ListrLogLevels {
   ROLLBACK = 'ROLLBACK',
   RETRY = 'RETRY',
   PROMPT = 'PROMPT',
-  PAUSED = 'PAUSED'
+  PAUSED = 'PAUSED',
+  CANCELLED = 'CANCELLED'
 }
 
 export const LISTR_LOGGER_STYLE: ListrLoggerStyleMap<ListrLogLevels> = {
@@ -25,7 +26,8 @@ export const LISTR_LOGGER_STYLE: ListrLoggerStyleMap<ListrLogLevels> = {
     [ListrLogLevels.TITLE]: figures.arrowRight,
     [ListrLogLevels.RETRY]: figures.warning,
     [ListrLogLevels.ROLLBACK]: figures.arrowLeft,
-    [ListrLogLevels.PAUSED]: figures.squareSmallFilled
+    [ListrLogLevels.PAUSED]: figures.squareSmallFilled,
+    [ListrLogLevels.CANCELLED]: figures.circleSlash
   },
   color: {
     [ListrLogLevels.STARTED]: color.yellow,
@@ -34,7 +36,8 @@ export const LISTR_LOGGER_STYLE: ListrLoggerStyleMap<ListrLogLevels> = {
     [ListrLogLevels.COMPLETED]: color.green,
     [ListrLogLevels.RETRY]: color.yellowBright,
     [ListrLogLevels.ROLLBACK]: color.redBright,
-    [ListrLogLevels.PAUSED]: color.yellowBright
+    [ListrLogLevels.PAUSED]: color.yellowBright,
+    [ListrLogLevels.CANCELLED]: color.red
   }
 }
 

--- a/packages/listr2/tests/__snapshots__/signal-handler.e2e-spec.ts.snap
+++ b/packages/listr2/tests/__snapshots__/signal-handler.e2e-spec.ts.snap
@@ -1,5 +1,95 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`signal handlers should mark still-pending tasks as cancelled on interrupt: Fn4Ld6WpQr8YtX2mB0KsJ5ZcV7hG3aEu-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`signal handlers should mark still-pending tasks as cancelled on interrupt: Fn4Ld6WpQr8YtX2mB0KsJ5ZcV7hG3aEu-stderr 1`] = `[]`;
+
+exports[`signal handlers should mark still-pending tasks as cancelled on interrupt: Fn4Ld6WpQr8YtX2mB0KsJ5ZcV7hG3aEu-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"running","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["running"]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"running","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["running"]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"queued one","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["queued one"]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"queued two","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["queued two"]}}
+",
+]
+`;
+
+exports[`signal handlers should run the rollback of a task when interrupted, not cancel it: aQ9mZ2kR7wT4xB1nC6vL0pF3sD8gH5jU-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`signal handlers should run the rollback of a task when interrupted, not cancel it: aQ9mZ2kR7wT4xB1nC6vL0pF3sD8gH5jU-stderr 1`] = `
+[
+  "{"event":"MESSAGE","data":{"error":"Interrupted."},"task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"MESSAGE","data":{"rollback":"a task"},"task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+]
+`;
+
+exports[`signal handlers should run the rollback of a task when interrupted, not cancel it: aQ9mZ2kR7wT4xB1nC6vL0pF3sD8gH5jU-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"STATE","data":"ROLLING_BACK","task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"STATE","data":"ROLLED_BACK","task":{"hasRolledBack":true,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+]
+`;
+
+exports[`signal handlers should still exit and rollback when exitAfterRollback is false: Vw2NpT6RcX9KdL4mB1QsJ7ZfG0hY5aEi-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`signal handlers should still exit and rollback when exitAfterRollback is false: Vw2NpT6RcX9KdL4mB1QsJ7ZfG0hY5aEi-stderr 1`] = `
+[
+  "{"event":"MESSAGE","data":{"error":"Interrupted."},"task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"MESSAGE","data":{"rollback":"a task"},"task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+]
+`;
+
+exports[`signal handlers should still exit and rollback when exitAfterRollback is false: Vw2NpT6RcX9KdL4mB1QsJ7ZfG0hY5aEi-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"STATE","data":"ROLLING_BACK","task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"STATE","data":"ROLLED_BACK","task":{"hasRolledBack":true,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+]
+`;
+
+exports[`signal handlers should still exit when the interrupted failure is swallowed by exitOnError false: Bq7Kd2XpRn4YtM8LwZ0FsC6VjH3gA9Eu-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`signal handlers should still exit when the interrupted failure is swallowed by exitOnError false: Bq7Kd2XpRn4YtM8LwZ0FsC6VjH3gA9Eu-stderr 1`] = `[]`;
+
+exports[`signal handlers should still exit when the interrupted failure is swallowed by exitOnError false: Bq7Kd2XpRn4YtM8LwZ0FsC6VjH3gA9Eu-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+",
+]
+`;
+
 exports[`signal handlers should try to cancel running tasks: ACxcRBILlHsqiSxYArjASFdofVqLaUyE-exit 1`] = `
 [
   127,
@@ -16,7 +106,7 @@ exports[`signal handlers should try to cancel running tasks: ACxcRBILlHsqiSxYArj
 ",
   "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
 ",
-  "{"event":"STATE","data":"FAILED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":true,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
 ",
 ]
 `;
@@ -33,7 +123,7 @@ exports[`signal handlers should try to cancel running tasks: LFRhPFJHChAJcQIEadk
 [
   "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
 ",
-  "{"event":"STATE","data":"FAILED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":true,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"a task","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["a task"]}}
 ",
 ]
 `;

--- a/packages/listr2/tests/renderer/__snapshots__/cancel.e2e-spec.ts.snap
+++ b/packages/listr2/tests/renderer/__snapshots__/cancel.e2e-spec.ts.snap
@@ -1,0 +1,286 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`default renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`default renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stderr 1`] = `[]`;
+
+exports[`default renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stdout 1`] = `
+[
+  "[?25l",
+  "[2m◼[22m This parent will be cancelled.
+",
+  "[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+",
+  "[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [2m◼[22m This subtask will trigger the interruption.
+",
+  "[2K[1A[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [2m◼[22m This subtask will trigger the interruption.
+  [2m◼[22m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [33m❯[39m This subtask will trigger the interruption.
+  [2m◼[22m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [33m❯[39m This subtask will trigger the interruption.
+  [33m❯[39m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [31m⊘[39m This subtask will trigger the interruption.
+  [33m❯[39m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This parent will be cancelled.
+  [31m⊘[39m This subtask will trigger the interruption.
+  [31m⊘[39m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This parent will be cancelled.
+  [31m⊘[39m This subtask will trigger the interruption.
+  [31m⊘[39m This subtask will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[31m⊘[39m This parent will be cancelled.
+  [31m⊘[39m This subtask will trigger the interruption.
+  [31m⊘[39m This subtask will be cancelled.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`default renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stderr 1`] = `[]`;
+
+exports[`default renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stdout 1`] = `
+[
+  "[?25l",
+  "[2m◼[22m This task will trigger the interruption.
+",
+  "[2K[1A[2K[G[2m◼[22m This task will trigger the interruption.
+[2m◼[22m This task will roll back.
+",
+  "[2K[1A[2K[1A[2K[G[2m◼[22m This task will trigger the interruption.
+[2m◼[22m This task will roll back.
+[2m◼[22m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This task will trigger the interruption.
+[2m◼[22m This task will roll back.
+[2m◼[22m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This task will trigger the interruption.
+[33m❯[39m This task will roll back.
+[2m◼[22m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[33m❯[39m This task will trigger the interruption.
+[33m❯[39m This task will roll back.
+[33m❯[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This task will trigger the interruption.
+[33m❯[39m This task will roll back.
+[33m❯[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This task will trigger the interruption.
+[91m⚠[39m This task will roll back.
+[33m❯[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This task will trigger the interruption.
+[91m⚠[39m This task has rolled back.
+[33m❯[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This task will trigger the interruption.
+[91m⚠[39m This task has rolled back.
+[31m⊘[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G[31m⊘[39m This task will trigger the interruption.
+[91m←[39m This task has rolled back.
+[31m⊘[39m This task will be cancelled.
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[31m⊘[39m This task will trigger the interruption.
+[91m←[39m This task has rolled back.
+[31m⊘[39m This task will be cancelled.
+",
+  "[?25h",
+]
+`;
+
+exports[`simple renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`simple renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stderr 1`] = `[]`;
+
+exports[`simple renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stdout 1`] = `
+[
+  "[33m❯[39m This parent will be cancelled.
+",
+  "[33m❯[39m This subtask will trigger the interruption.
+",
+  "[33m❯[39m This subtask will be cancelled.
+",
+  "[31m⊘[39m This subtask will trigger the interruption.
+",
+  "[31m⊘[39m This subtask will be cancelled.
+",
+  "[31m⊘[39m This parent will be cancelled.
+",
+]
+`;
+
+exports[`simple renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`simple renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stderr 1`] = `
+[
+  "[31m✖[39m This task will roll back. [31m[FAILED: Interrupted.][39m
+",
+  "[91m←[39m This task has rolled back. [31m[ROLLBACK: This task has rolled back.][39m
+",
+]
+`;
+
+exports[`simple renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stdout 1`] = `
+[
+  "[33m❯[39m This task will trigger the interruption.
+",
+  "[33m❯[39m This task will roll back.
+",
+  "[33m❯[39m This task will be cancelled.
+",
+  "[31m⊘[39m This task will trigger the interruption.
+",
+  "[31m⊘[39m This task will be cancelled.
+",
+]
+`;
+
+exports[`test renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`test renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stderr 1`] = `[]`;
+
+exports[`test renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This parent will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled."]}}
+",
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This subtask will trigger the interruption.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled.","This subtask will trigger the interruption."]}}
+",
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This subtask will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled.","This subtask will be cancelled."]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This subtask will trigger the interruption.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled.","This subtask will trigger the interruption."]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This subtask will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled.","This subtask will be cancelled."]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":true,"title":"This parent will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This parent will be cancelled."]}}
+",
+]
+`;
+
+exports[`test renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`test renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stderr 1`] = `
+[
+  "{"event":"MESSAGE","data":{"error":"Interrupted."},"task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will roll back.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+  "{"event":"MESSAGE","data":{"rollback":"This task has rolled back."},"task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task has rolled back.","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+]
+`;
+
+exports[`test renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stdout 1`] = `
+[
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will trigger the interruption.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will trigger the interruption."]}}
+",
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will roll back.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+  "{"event":"STATE","data":"STARTED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":true,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will be cancelled."]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task will trigger the interruption.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will trigger the interruption."]}}
+",
+  "{"event":"STATE","data":"ROLLING_BACK","task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task will roll back.","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+  "{"event":"TITLE","data":"This task has rolled back.","task":{"hasRolledBack":false,"isRollingBack":true,"isCompleted":false,"isSkipped":false,"hasFinalized":false,"hasSubtasks":false,"title":"This task has rolled back.","hasReset":true,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":true,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+  "{"event":"STATE","data":"CANCELLED","task":{"hasRolledBack":false,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task will be cancelled.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will be cancelled."]}}
+",
+  "{"event":"STATE","data":"ROLLED_BACK","task":{"hasRolledBack":true,"isRollingBack":false,"isCompleted":false,"isSkipped":false,"hasFinalized":true,"hasSubtasks":false,"title":"This task has rolled back.","hasReset":false,"hasTitle":true,"isPrompt":false,"isPaused":false,"isPending":false,"isStarted":false,"hasFailed":false,"isEnabled":true,"isRetrying":false,"path":["This task will roll back."]}}
+",
+]
+`;
+
+exports[`verbose renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`verbose renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stderr 1`] = `[]`;
+
+exports[`verbose renderer: cancel should render a cancelled subtask tree on interruption: Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz-stdout 1`] = `
+[
+  "[33m[STARTED][39m This parent will be cancelled.
+",
+  "[33m[STARTED][39m This subtask will trigger the interruption.
+",
+  "[33m[STARTED][39m This subtask will be cancelled.
+",
+  "[31m[CANCELLED][39m This subtask will trigger the interruption.
+",
+  "[31m[CANCELLED][39m This subtask will be cancelled.
+",
+  "[31m[CANCELLED][39m This parent will be cancelled.
+",
+]
+`;
+
+exports[`verbose renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-exit 1`] = `
+[
+  127,
+]
+`;
+
+exports[`verbose renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stderr 1`] = `
+[
+  "[31m[FAILED][39m Interrupted.
+",
+  "[91m[ROLLBACK][39m This task has rolled back.
+",
+]
+`;
+
+exports[`verbose renderer: cancel should render cancelled and rolled back tasks on interruption: Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE-stdout 1`] = `
+[
+  "[33m[STARTED][39m This task will trigger the interruption.
+",
+  "[33m[STARTED][39m This task will roll back.
+",
+  "[33m[STARTED][39m This task will be cancelled.
+",
+  "[31m[CANCELLED][39m This task will trigger the interruption.
+",
+  "[TITLE] This task has rolled back.
+",
+  "[31m[CANCELLED][39m This task will be cancelled.
+",
+]
+`;

--- a/packages/listr2/tests/renderer/cancel.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/cancel.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { delay, Listr } from '@root'
+import type { MockProcessOutput, RendererSetup } from '@tests/utils'
+import { expectProcessOutputToMatchSnapshot, mockProcessOutput, unmockProcessOutput, RENDERER_SETUP } from '@tests/utils'
+
+// keeps a task in-flight until the interruption races it out, without leaving a real timer alive past the test
+const hang = (): Promise<void> => new Promise<void>(() => undefined)
+
+describe.each<RendererSetup>(RENDERER_SETUP)('%s renderer: cancel', (renderer, rendererOptions) => {
+  const output: MockProcessOutput = {} as MockProcessOutput
+
+  process.stdout.isTTY = true
+
+  beforeEach(async() => {
+    mockProcessOutput(output)
+  })
+
+  afterEach(async() => {
+    unmockProcessOutput(output)
+    jest.clearAllMocks()
+  })
+
+  // Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE
+  it('should render cancelled and rolled back tasks on interruption', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will trigger the interruption.',
+          task: async(_, task): Promise<void> => {
+            await delay(50)
+
+            task.cancel()
+
+            await hang()
+          }
+        },
+        {
+          title: 'This task will roll back.',
+          task: async(): Promise<void> => {
+            await hang()
+          },
+          rollback: async(_, task): Promise<void> => {
+            task.title = 'This task has rolled back.'
+          }
+        },
+        {
+          title: 'This task will be cancelled.',
+          task: async(): Promise<void> => {
+            await hang()
+          }
+        }
+      ],
+      {
+        concurrent: true,
+        renderer,
+        rendererOptions
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'Cn7xKp2RtLm4Wq8YvB0ZsJ5dF3gH9aE')
+  })
+
+  // Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz
+  it('should render a cancelled subtask tree on interruption', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This parent will be cancelled.',
+          task: (_, task): Listr =>
+            task.newListr(
+              [
+                {
+                  title: 'This subtask will trigger the interruption.',
+                  task: async(_, task): Promise<void> => {
+                    await delay(50)
+
+                    task.cancel()
+
+                    await hang()
+                  }
+                },
+                {
+                  title: 'This subtask will be cancelled.',
+                  task: async(): Promise<void> => {
+                    await hang()
+                  }
+                }
+              ],
+              { concurrent: true }
+            )
+        }
+      ],
+      {
+        concurrent: false,
+        renderer,
+        rendererOptions
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'Nx4Jm8QrTp2WkD6cV0PbL5YfS9gH3aBz')
+  })
+})

--- a/packages/listr2/tests/signal-handler.e2e-spec.ts
+++ b/packages/listr2/tests/signal-handler.e2e-spec.ts
@@ -2,6 +2,9 @@ import type { MockProcessOutput } from './utils'
 import { expectProcessOutputToMatchSnapshot, mockProcessOutput, unmockProcessOutput } from './utils'
 import { Listr, delay } from '@root'
 
+// keeps a task in-flight until the interruption races it out, without leaving a real timer alive past the test
+const hang = (): Promise<void> => new Promise<void>(() => undefined)
+
 describe('signal handlers', () => {
   const output: MockProcessOutput = {} as MockProcessOutput
 
@@ -27,7 +30,7 @@ describe('signal handlers', () => {
 
             process.emit('SIGINT')
 
-            await delay(100)
+            await hang()
           }
         }
       ],
@@ -67,7 +70,7 @@ describe('signal handlers', () => {
 
             process.emit('SIGINT')
 
-            await delay(100)
+            await hang()
           }
         }
       ],
@@ -79,6 +82,406 @@ describe('signal handlers', () => {
     ).run()
 
     expectProcessOutputToMatchSnapshot(output, 'ACxcRBILlHsqiSxYArjASFdofVqLaUyE')
+  })
+
+  // aQ9mZ2kR7wT4xB1nC6vL0pF3sD8gH5jU
+  it('should run the rollback of a task when interrupted, not cancel it', async() => {
+    let rolledBack = false
+
+    const list = new Listr(
+      [
+        {
+          title: 'a task',
+          task: async(): Promise<void> => {
+            await delay(10)
+
+            process.emit('SIGINT')
+
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    await list.run()
+
+    expect(rolledBack).toBe(true)
+    expect(list.tasks[0].hasRolledBack()).toBe(true)
+    expect(list.tasks[0].isCancelled()).toBe(false)
+    expectProcessOutputToMatchSnapshot(output, 'aQ9mZ2kR7wT4xB1nC6vL0pF3sD8gH5jU')
+  })
+
+  // Bq7Kd2XpRn4YtM8LwZ0FsC6VjH3gA9Eu
+  it('should still exit when the interrupted failure is swallowed by exitOnError false', async() => {
+    await new Listr(
+      [
+        {
+          title: 'a task',
+          task: async(): Promise<void> => {
+            await delay(10)
+
+            process.emit('SIGINT')
+
+            await hang()
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        exitOnError: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    ).run()
+
+    expect(output.exit).toHaveBeenCalledWith(127)
+    expectProcessOutputToMatchSnapshot(output, 'Bq7Kd2XpRn4YtM8LwZ0FsC6VjH3gA9Eu')
+  })
+
+  // Vw2NpT6RcX9KdL4mB1QsJ7ZfG0hY5aEi
+  it('should still exit and rollback when exitAfterRollback is false', async() => {
+    let rolledBack = false
+
+    await new Listr(
+      [
+        {
+          title: 'a task',
+          task: async(): Promise<void> => {
+            await delay(10)
+
+            process.emit('SIGINT')
+
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        exitAfterRollback: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    ).run()
+
+    expect(rolledBack).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
+    expectProcessOutputToMatchSnapshot(output, 'Vw2NpT6RcX9KdL4mB1QsJ7ZfG0hY5aEi')
+  })
+
+  it('should settle all concurrent sibling rollbacks before the parent rolls back', async() => {
+    const order: string[] = []
+
+    await new Listr(
+      [
+        {
+          title: 'parent',
+          task: (_, task): Listr =>
+            task.newListr(
+              [
+                {
+                  title: 'child-a',
+                  task: async(): Promise<void> => {
+                    await delay(10)
+
+                    process.emit('SIGINT')
+
+                    await hang()
+                  },
+                  rollback: async(): Promise<void> => {
+                    await delay(5)
+
+                    order.push('child-a')
+                  }
+                },
+                {
+                  title: 'child-b',
+                  task: async(): Promise<void> => {
+                    await hang()
+                  },
+                  rollback: async(): Promise<void> => {
+                    await delay(50)
+
+                    order.push('child-b')
+                  }
+                }
+              ],
+              { concurrent: true }
+            ),
+          rollback: async(): Promise<void> => {
+            order.push('parent')
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    ).run()
+
+    expect(order).toEqual(['child-a', 'child-b', 'parent'])
+    expect(output.exit).toHaveBeenCalledWith(127)
+  })
+
+  // Fn4Ld6WpQr8YtX2mB0KsJ5ZcV7hG3aEu
+  it('should mark still-pending tasks as cancelled on interrupt', async() => {
+    const list = new Listr(
+      [
+        {
+          title: 'running',
+          task: async(): Promise<void> => {
+            await delay(10)
+
+            process.emit('SIGINT')
+
+            await hang()
+          }
+        },
+        {
+          title: 'queued one',
+          task: async(): Promise<void> => {
+            await delay(50)
+          }
+        },
+        {
+          title: 'queued two',
+          task: async(): Promise<void> => {
+            await delay(50)
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    await list.run()
+
+    expect(list.tasks.every((task) => task.isCancelled() && task.hasFinalized() && !task.hasFailed())).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
+    expectProcessOutputToMatchSnapshot(output, 'Fn4Ld6WpQr8YtX2mB0KsJ5ZcV7hG3aEu')
+  })
+
+  it('should interrupt the run programmatically with cancel()', async() => {
+    let rolledBack = false
+
+    const list = new Listr(
+      [
+        {
+          title: 'trigger',
+          task: async(_, task): Promise<void> => {
+            await delay(10)
+
+            task.cancel()
+
+            await hang()
+          }
+        },
+        {
+          title: 'sibling',
+          task: async(): Promise<void> => {
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: true,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    await list.run()
+
+    expect(rolledBack).toBe(true)
+    expect(list.tasks[0].isCancelled()).toBe(true)
+    expect(list.tasks[1].hasRolledBack()).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
+  })
+
+  it('should abort task.signal for cooperative cancellation and share it across the tree', async() => {
+    let aborted = false
+    let workerSignal: AbortSignal | undefined
+    let subtaskSignal: AbortSignal | undefined
+
+    const list = new Listr(
+      [
+        {
+          title: 'canceller',
+          task: async(_, task): Promise<void> => {
+            await delay(20)
+
+            task.cancel()
+          }
+        },
+        {
+          title: 'worker',
+          task: (_, task): Listr => {
+            workerSignal = task.signal
+
+            task.signal.addEventListener('abort', () => {
+              aborted = true
+            })
+
+            return task.newListr([
+              {
+                title: 'subtask',
+                task: async(_, subtask): Promise<void> => {
+                  subtaskSignal = subtask.signal
+
+                  await hang()
+                }
+              }
+            ])
+          }
+        }
+      ],
+      {
+        concurrent: true,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    await list.run()
+
+    expect(aborted).toBe(true)
+    expect(list.signal.aborted).toBe(true)
+    expect(workerSignal).toBe(list.signal)
+    expect(subtaskSignal).toBe(list.signal)
+  })
+
+  it('should cancel programmatically even with registerSignalListeners disabled', async() => {
+    let rolledBack = false
+
+    const list = new Listr(
+      [
+        {
+          title: 'canceller',
+          task: async(_, task): Promise<void> => {
+            await delay(10)
+
+            task.cancel()
+
+            await hang()
+          }
+        },
+        {
+          title: 'sibling',
+          task: async(): Promise<void> => {
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: true,
+        renderer: 'test',
+        registerSignalListeners: false
+      }
+    )
+
+    await list.run()
+
+    expect(rolledBack).toBe(true)
+    expect(list.tasks[0].isCancelled()).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
+  })
+
+  it('should cancel the run from outside with listr.cancel()', async() => {
+    let rolledBack = false
+
+    const list = new Listr(
+      [
+        {
+          title: 'a task',
+          task: async(): Promise<void> => {
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    const promise = list.run()
+
+    await delay(20)
+
+    list.cancel()
+
+    await promise
+
+    expect(rolledBack).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
+  })
+
+  it('should cancel the run from a subtask', async() => {
+    let rolledBack = false
+
+    const list = new Listr(
+      [
+        {
+          title: 'parent',
+          task: (_, task): Listr =>
+            task.newListr([
+              {
+                title: 'subtask',
+                task: async(_, subtask): Promise<void> => {
+                  await delay(10)
+
+                  subtask.cancel()
+
+                  await hang()
+                }
+              }
+            ])
+        },
+        {
+          title: 'sibling',
+          task: async(): Promise<void> => {
+            await hang()
+          },
+          rollback: async(): Promise<void> => {
+            rolledBack = true
+          }
+        }
+      ],
+      {
+        concurrent: true,
+        renderer: 'test',
+        registerSignalListeners: true
+      }
+    )
+
+    await list.run()
+
+    expect(rolledBack).toBe(true)
+    expect(output.exit).toHaveBeenCalledWith(127)
   })
 
   it('should not clear other SIGINT listeners', async() => {


### PR DESCRIPTION
## Open Issue

Closes K-703 · [#769](https://github.com/listr2/listr2/issues/769)

## Preflight

- [x] Create an issue for a preliminary discussion or link the existing issue.
- [x] Follow guidelines enforced by `git-hooks` of linting, tests, and commit convention, which is [Angular conventional commits](https://www.conventionalcommits.org/).
- [x] Add tests whenever or if possible.
- [x] Update the documentation.

## Summary

Implements the [#769](https://github.com/listr2/listr2/issues/769) feature request — run task `rollback` on `Ctrl+C` — along with the surrounding cancellation story.

- **Rollback on interruption** — `SIGINT` now runs the `rollback` of any in-flight task that defines one and defers the `exit(127)` until every in-flight rollback has settled (nested rollbacks run innermost-first), instead of failing tasks and exiting synchronously. Modeled as a shared `AbortController` racing into `Task.run`, so it reuses the existing rollback catch path.
- **New `CANCELLED` task state** — interrupted tasks without a rollback, and tasks that never started, are marked `ListrTaskState.CANCELLED` (with a `task.isCancelled()` helper) instead of `FAILED`. Rendered as a `⊘` in the default renderer and a cancelled line in the simple/verbose renderers.
- **`task.signal`** — exposes the run's `AbortSignal` for cooperative cancellation of a task's own async work (`fetch`, child processes, timers).
- **`listr.cancel()` / `task.cancel()`** — interrupt a run programmatically without an operating-system signal.

## Breaking Changes

- On interruption, tasks without a `rollback` are now marked as `CANCELLED` instead of `FAILED`, and the process exits only after in-flight rollbacks have settled. Custom renderers that switch on the task state must handle `ListrTaskState.CANCELLED`. Documented in `docs/migration/v11.md`.

## Notes

- Cancellation output is written to `stdout` (unlike `FAILED`/`ROLLBACK`, which go to `stderr`), since a `Ctrl+C` cancel is a user action rather than an error.
- Also folds in a small documentation fix replacing stale `colorette` references with `node:util`'s `styleText` (the color library was swapped in #758).