### PR TITLE
fix: return null from Listr.errors when error collection is disabled

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -11,6 +11,7 @@ order: 60
 
 - The internal event handling now uses `node.js`'s built-in `EventEmitter` instead of `eventemitter3`, and the `eventemitter3` dependency has been dropped. <GithubIssue :issue="759" />
 - The _Listr_ option `collectErrors` is now a `boolean` instead of `false | 'minimal' | 'full'`. Use `true` for the previous `'minimal'` behavior, the `'full'` mode has been removed.
+- When error collection is disabled through `collectErrors` — which is still the default — `Listr.errors` is now `null` instead of an empty array. An empty array now unambiguously means collection is enabled and no errors have been encountered, so guard reads with `listr.errors?.length` or an explicit `null` check. Because the collection is shared from the root of the run, `collectErrors` is now effectively root-scoped: enabling it only on a subtask while the root leaves it disabled no longer collects those errors. <GithubIssue :issue="751" />
 - `ListrError` no longer clones the context in to the error instance and its `ctx` property has been removed. Only the `error`, its `type` and the `path` of the failed task are collected.
 - Dropped the `rfdc` dependency and removed the `cloneObject` utility from the exports, which were only used by the removed `'full'` error collection mode.
 - Interrupting a run with `Ctrl+C` (`SIGINT`) now runs the `rollback` of any in-flight task that defines one and defers the `exit(127)` until every in-flight rollback has settled, instead of marking the pending tasks as failed and exiting synchronously. <GithubIssue :issue="769" />

--- a/docs/task/error-handling.md
+++ b/docs/task/error-handling.md
@@ -37,7 +37,7 @@ Throwing an error will stop any further action from the current _Task_ and will 
 
 ::: info
 
-You don't have to catch and collect errors explicitly since they will always be collected by _Listr_.
+You don't have to catch errors explicitly since they will always be handled and surfaced by _Listr_. Collecting them into `Listr.errors` for later inspection is a separate, opt-in behavior covered below.
 
 :::
 
@@ -88,6 +88,8 @@ Since there are options to ignore some errors on cases like `exitOnError`, or th
 Error collection is toggled per _Task_ through the _Listr_ options with the key `collectErrors`, which is a `boolean`. The default is `false` since this is the most-underused functionality, and it should be at least opt-in for saving some memory.
 
 Setting it to `true` will collect where the error has occurred, when it has been encountered and what the `error.message` is. The context is no longer cloned in to the `ListrError` to avoid potential memory leaks and issues with cloning non-serializable values.
+
+While collection is disabled, `Listr.errors` is `null` instead of an empty array. This way an empty array always means that collection is enabled and no errors have been encountered yet, while `null` means the errors were never collected. Guard reads with `listr.errors?.length` or an explicit `null` check.
 
 ### ListrError
 

--- a/examples/error-handling.example.ts
+++ b/examples/error-handling.example.ts
@@ -134,7 +134,9 @@ async function main(): Promise<void> {
         }
       }
     ],
-    { concurrent: false, exitOnError: true }
+    {
+      concurrent: false, exitOnError: true, collectErrors: true
+    }
   )
 
   try {

--- a/examples/subtasks.example.ts
+++ b/examples/subtasks.example.ts
@@ -174,7 +174,9 @@ task = new Listr<Ctx>(
       }
     }
   ],
-  { concurrent: false, exitOnError: true }
+  {
+    concurrent: false, exitOnError: true, collectErrors: true
+  }
 )
 
 try {

--- a/packages/listr2/src/interfaces/listr.interface.ts
+++ b/packages/listr2/src/interfaces/listr.interface.ts
@@ -56,7 +56,7 @@ export interface ListrOptions<Ctx = ListrContext> {
   /**
    * Collects errors inside the `Listr.errors`.
    *
-   * - `false` will collect no errors.
+   * - `false` will collect no errors, leaving `Listr.errors` as `null`.
    * - `true` will collect the error message, the type and the location of the failed task.
    *
    * @defaultValue `false`

--- a/packages/listr2/src/lib/task-wrapper.ts
+++ b/packages/listr2/src/lib/task-wrapper.ts
@@ -104,7 +104,7 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory, FallbackRen
    */
   public report(error: Error, type: ListrErrorTypes): void {
     if (this.task.options.collectErrors) {
-      this.task.listr.errors.push(new ListrError<Ctx>(error, type, this.task))
+      this.task.listr.errors?.push(new ListrError<Ctx>(error, type, this.task))
     }
 
     this.task.message$ = { error: error.message ?? this.task?.title }

--- a/packages/listr2/src/listr.ts
+++ b/packages/listr2/src/listr.ts
@@ -29,7 +29,7 @@ export class Listr<
   FallbackRenderer extends ListrRendererValue = ListrSecondaryRendererValue
 > {
   public tasks: Task<Ctx, ListrGetRendererClassFromValue<Renderer>, ListrGetRendererClassFromValue<FallbackRenderer>>[] = []
-  public errors: ListrError<Ctx>[] = []
+  public errors: ListrError<Ctx>[] | null
   public ctx: Ctx
   public events: ListrEventManager
   public path: string[] = []
@@ -80,6 +80,9 @@ export class Listr<
     if (parentTask) {
       this.path = [...parentTask.listr.path, parentTask.title]
       this.errors = parentTask.listr.errors
+    } else {
+      // null when disabled keeps "collected, none failed" ([]) distinct from "not collected"
+      this.errors = this.options.collectErrors ? [] : null
     }
 
     if (this.parentTask?.listr.events instanceof ListrEventManager) {

--- a/packages/listr2/tests/error-collection.e2e-spec.ts
+++ b/packages/listr2/tests/error-collection.e2e-spec.ts
@@ -5,6 +5,7 @@ describe('error collection', () => {
     const task = new Listr([])
 
     expect(task.options.collectErrors).toBe(false)
+    expect(task.errors).toBeNull()
   })
 
   it('should collect only the first error while exiting on error', async() => {
@@ -464,6 +465,82 @@ describe('error collection', () => {
 
     expect(result).toBeTruthy()
     expect(crash).toBeFalsy()
-    expect(task.errors).toHaveLength(0)
+    expect(task.errors).toBeNull()
+  })
+
+  it('should keep errors null through a run with failing subtasks when collection is disabled', async() => {
+    const task = new Listr(
+      [
+        {
+          task: (_, task): Listr =>
+            task.newListr(
+              [
+                {
+                  task: (): void => {
+                    throw new Error('subtask failed.')
+                  }
+                }
+              ],
+              { exitOnError: false }
+            )
+        }
+      ],
+      {
+        renderer: 'silent',
+        exitOnError: false,
+        collectErrors: false
+      }
+    )
+
+    await task.run()
+
+    expect(task.errors).toBeNull()
+  })
+
+  it('should stay null when only a subtask enables collection under a disabled root', async() => {
+    const task = new Listr(
+      [
+        {
+          task: (_, task): Listr =>
+            task.newListr(
+              [
+                {
+                  task: (): void => {
+                    throw new Error('subtask failed.')
+                  }
+                }
+              ],
+              { exitOnError: false, collectErrors: true }
+            )
+        }
+      ],
+      {
+        renderer: 'silent',
+        exitOnError: false,
+        collectErrors: false
+      }
+    )
+
+    await task.run()
+
+    expect(task.errors).toBeNull()
+  })
+
+  it('should expose an empty array when collection is enabled but nothing fails', async() => {
+    const task = new Listr(
+      [
+        {
+          task: (): void => {}
+        }
+      ],
+      {
+        renderer: 'silent',
+        collectErrors: true
+      }
+    )
+
+    await task.run()
+
+    expect(task.errors).toStrictEqual([])
   })
 })

--- a/packages/manager/src/manager.ts
+++ b/packages/manager/src/manager.ts
@@ -100,7 +100,7 @@ export class Manager<
     const ctx = await task.run()
 
     // reset error queue
-    this.errors.push(...task.errors)
+    this.errors.push(...(task.errors ?? []))
 
     return ctx
   }


### PR DESCRIPTION
## Open Issue

Closes K-715 · [#751](https://github.com/listr2/listr2/issues/751)

## Preflight

- [x] Create an issue for a preliminary discussion or link the existing issue.
- [x] Follow guidelines enforced by `git-hooks` of linting, tests, and commit convention, which is [Angular conventional commits](https://www.conventionalcommits.org/).
- [x] Add tests whenever or if possible.
- [x] Update the documentation.

## Summary

Fixes [#751](https://github.com/listr2/listr2/issues/751): with the default `collectErrors: false`, `Listr.errors` was always an empty array, so a consumer checking `if (listr.errors.length)` could not distinguish "collected, nothing failed" from "not collected" — a silent footgun.

- **`Listr.errors` is `null` when collection is disabled** and an array once `collectErrors` is enabled. An empty array now unambiguously means "collection on, nothing failed"; `null` means "not collected". The `report()` push site is null-safe.
- **`@listr2/manager`** no longer spreads the now-nullable `task.errors` unconditionally when aggregating.
- Documentation and the two error-handling examples updated for the new contract.

## Breaking Changes

- `Listr.errors` is now typed `ListrError[] | null` and is `null` under the default `collectErrors: false` (previously `[]`). Guard reads with `listr.errors?.length` or an explicit `null` check. Because the collection is shared from the root of the run, `collectErrors` is now effectively root-scoped — enabling it only on a subtask under a disabled root no longer collects. Documented in `docs/migration/v11.md`.

## Notes

- Shipped as a `fix` carrying a `BREAKING CHANGE:` footer so `multi-semantic-release` cuts a major on the `beta` line; the `@listr2/manager` guard ships as its own `fix`.
