### PR TITLE
fix(renderer): stop leaking output listeners on finalized tasks

### DIFF
--- a/docs/migration/v11.md
+++ b/docs/migration/v11.md
@@ -23,6 +23,7 @@ order: 60
 - [x] expose the run's `AbortSignal` on the task wrapper as `task.signal`, so task functions can cooperatively cancel their own asynchronous work like `fetch`, child processes or timers when the run is interrupted <GithubIssue :issue="769" />
 - [x] add `listr.cancel()` and `task.cancel()` to interrupt a run programmatically without an operating-system signal, rolling back or cancelling the in-flight tasks the same way `Ctrl+C` does <GithubIssue :issue="769" />
 - [x] upgrade `log-update` to `v8` and `cli-truncate` to `v6`, enabling partial/differential rendering in the default renderer — the task list is redrawn with smaller, targeted terminal writes wrapped in synchronized-output markers (`ESC[?2026h`/`ESC[?2026l`) on supporting terminals, reducing flicker. The visible output is unchanged.
+- [x] fix a memory leak in the default renderer where a finalized task had its output buffer re-created and its listeners re-attached on every render, which exhausted the heap when another task streamed to `task.output` at a high rate over a long run <GithubIssue :issue="772" />
 
 ## Node.js Support
 

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -505,6 +505,12 @@ export class DefaultRenderer implements ListrRenderer {
       return
     }
 
+    // finalized tasks have their non-persistent buffers torn down every render pass below; re-creating them here would
+    // re-attach the output and state listeners each pass and leak them, so leave them until the task runs again
+    if (task.hasFinalized()) {
+      return
+    }
+
     const rendererTaskOptions = this.cache.rendererTaskOptions.get(task.id)
 
     // lazily create the process output buffer for the current task output

--- a/packages/listr2/tests/renderer/default/output-leak.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/default/output-leak.e2e-spec.ts
@@ -1,0 +1,54 @@
+import type EventEmitter from 'node:events'
+
+import { ListrTaskEventType } from '@constants'
+import { Listr, delay } from '@root'
+import type { MockProcessOutput } from '@tests/utils'
+import { mockProcessOutput, unmockProcessOutput } from '@tests/utils'
+
+describe('default renderer: output buffer listeners', () => {
+  const output: MockProcessOutput = {} as MockProcessOutput
+
+  process.stdout.isTTY = true
+
+  // reaches the private emitter behind ListrTaskEventManager to count the listeners the renderer attaches to a task
+  function listenerCount(task: unknown, event: ListrTaskEventType): number {
+    return (task as { emitter: EventEmitter }).emitter.listenerCount(event)
+  }
+
+  beforeEach(() => {
+    mockProcessOutput(output)
+  })
+
+  afterEach(() => {
+    unmockProcessOutput(output)
+    jest.clearAllMocks()
+  })
+
+  // a finalized task used to have its output buffer re-created — and its output/state listeners re-attached — on every
+  // render, leaking without bound when another task streamed to task.output at a high rate over a long run
+  it('should not re-attach output listeners to a finalized task while another streams output', async() => {
+    const task = new Listr(
+      [
+        { title: 'finalizes early', task: (): void => undefined },
+        {
+          title: 'streams output',
+          task: async(_, subtask): Promise<void> => {
+            for (let i = 0; i < 100; i++) {
+              subtask.output = `output ${i}`
+
+              await delay(0)
+            }
+          }
+        }
+      ],
+      { concurrent: true, rendererOptions: { lazy: true } }
+    )
+
+    await task.run()
+
+    const finalized = task.tasks[0]
+
+    expect(listenerCount(finalized, ListrTaskEventType.OUTPUT)).toBeLessThanOrEqual(1)
+    expect(listenerCount(finalized, ListrTaskEventType.STATE)).toBeLessThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
## Open Issue

Closes K-702 · [#772](https://github.com/listr2/listr2/issues/772)

## Preflight

- [x] Create an issue for a preliminary discussion or link the existing issue.
- [x] Follow guidelines enforced by `git-hooks` of linting, tests, and commit convention, which is [Angular conventional commits](https://www.conventionalcommits.org/).
- [x] Add tests whenever or if possible.
- [x] Update the documentation.

## Summary

Fixes the out-of-memory crash ([#772](https://github.com/listr2/listr2/issues/772)) when a task streams to `task.output` at a high rate over a long run (e.g. ffmpeg progress, ~93k writes over ~44 min).

The root cause is a **listener leak**, not render frequency. The default renderer tears down a non-persistent finalized task's output buffer on every render (`renderer.ts:437-442`), and `setupBuffer` re-creates it on the next pass, re-attaching two `task.on(...)` listeners each time — silent because the task emitter runs with `setMaxListeners(0)`. Over a long run these accumulate without bound (millions of retained closures) and exhaust the heap. (`Task.closed` being dead — never assigned — also disables the render cache that would otherwise short-circuit this, so finalized subtrees are re-processed every frame.)

The fix skips re-creating the buffer once a task has finalized — a single guard in `setupBuffer`. Verified: the heap reaches steady state (~7 MB flat vs. linear growth to OOM), and a finalized task keeps **0 leaked listeners** across a 100-render stream (regression test included, mutation-checked at 103 without the guard).

## Breaking Changes

None. The rendered output is byte-for-byte unchanged — the fix is purely internal (no snapshot churn, no API change).

## Notes

- `process.nextTick` render-coalescing was investigated as an alternative, but it visibly drops sub-tick transient output in the examples, and the leak fix alone already bounds the heap even at the full render-per-write rate — so it was not adopted.
- Reviving `Task.closed` to re-enable the render cache is a real follow-up perf win but has UI blast radius (frozen cached frames), so it is intentionally left out of this fix.
