### PR TITLE
fix(renderer): honor the configured output stream width (stderr routing)

### DIFF
--- a/docs/renderer/process-output.md
+++ b/docs/renderer/process-output.md
@@ -41,3 +41,19 @@ If you do not like the behavior of the _ProcessOutput_, you can always implement
 <<< @../../examples/docs/renderer/process-output/change-behavior.ts
 
 :::
+
+## Routing All Output to `stderr`
+
+<GithubIssue :issue="716" />
+
+Since every renderer writes through the _ProcessOutput_ on the _ListrLogger_, you can keep `stdout` clean and pipeable (e.g. emitting `JSON` to pipe into `jq`) while the live UI and the final output still show up in the terminal by routing everything to `stderr`.
+
+Pass `process.stderr` for both the `stdout` and `stderr` slots of the _ProcessOutput_, then inject the logger into the renderer.
+
+There is one caveat: piping `stdout` makes it non-`TTY`, which normally steps _Listr_ down to the fallback renderer with a default logger. To keep the _DefaultRenderer_ and route the fallback through the same logger, set `forceTTY` and provide the logger on both `rendererOptions` and `fallbackRendererOptions`.
+
+::: details <CodeExampleIcon /> Code Example
+
+<<< @../../examples/docs/renderer/process-output/route-to-stderr.ts
+
+:::

--- a/examples/docs/renderer/process-output/route-to-stderr.ts
+++ b/examples/docs/renderer/process-output/route-to-stderr.ts
@@ -1,0 +1,25 @@
+import { delay, Listr, ListrLogger, ProcessOutput } from 'listr2'
+
+const logger = new ListrLogger({ processOutput: new ProcessOutput(process.stderr, process.stderr) })
+
+const tasks = new Listr(
+  [
+    {
+      title: 'This task will execute.',
+      task: async(_, task): Promise<void> => {
+        task.output = 'the live frames render on stderr'
+
+        await delay(500)
+      }
+    }
+  ],
+  {
+    forceTTY: true,
+    rendererOptions: { logger },
+    fallbackRendererOptions: { logger }
+  }
+)
+
+await tasks.run()
+
+process.stdout.write(JSON.stringify({ result: 'stdout stays clean and pipeable' }))

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -231,7 +231,7 @@ export class DefaultRenderer implements ListrRenderer {
 
     let parsed: string[]
 
-    const columns = (process.stdout.columns ?? 80) - level * this.options.indentation - 2
+    const columns = (this.logger.process.stdout.columns ?? 80) - level * this.options.indentation - 2
 
     switch (this.options.formatOutput) {
       case 'truncate':

--- a/packages/listr2/tests/renderer/default/wrap-width.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/default/wrap-width.e2e-spec.ts
@@ -1,0 +1,54 @@
+import { PassThrough } from 'stream'
+
+import { Listr, ListrLogger, ProcessOutput } from '@root'
+
+describe('default renderer: wrap width from configured stream', () => {
+  const message = 'THIS IS A LONG LONG MESSAGE '.repeat(12).trim()
+
+  it('should derive the wrap width from the logger stream instead of process.stdout', async() => {
+    const columns = process.stdout.columns
+
+    process.stdout.columns = 80
+
+    const stream = new PassThrough() as unknown as NodeJS.WriteStream
+
+    stream.columns = 200
+
+    const chunks: string[] = []
+
+    stream.on('data', (chunk) => chunks.push(chunk.toString()))
+
+    const logger = new ListrLogger({ processOutput: new ProcessOutput(stream, stream) })
+
+    await new Listr(
+      [
+        {
+          title: 'This task will wrap its output.',
+          task: async(_, task): Promise<void> => {
+            task.output = message
+          }
+        }
+      ],
+      {
+        forceTTY: true,
+        rendererOptions: {
+          lazy: true,
+          formatOutput: 'wrap',
+          logger
+        },
+        fallbackRendererOptions: { logger }
+      }
+    ).run()
+
+    process.stdout.columns = columns
+
+    const widest = chunks
+      .join('')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\[[0-9;]*[A-Za-z]/g, '')
+      .split('\n')
+      .reduce((max, line) => Math.max(max, line.length), 0)
+
+    expect(widest).toBeGreaterThan(80)
+  })
+})


### PR DESCRIPTION
## Summary

Resolves the "output to `stderr`" support request (#716) — you *can* route all of listr's live UI to `stderr` and keep `stdout` clean/pipeable; this fixes the one real library bug in that path and documents the recipe.

- **Fix** — the default renderer computed wrap/truncate width from a hard-coded `process.stdout.columns`, ignoring the `ProcessOutput` stream configured on the logger. Routing to `stderr` while piping `stdout` (the exact use case) therefore wrapped at 80 columns regardless of the real stream. It now reads the width from the stream the renderer actually writes to (`this.logger.process.stdout.columns`) — a no-op for the default `stdout` case, so **zero snapshot churn**. Covered by a new `wrap-width.e2e-spec.ts`.
- **Docs** — a new *Routing All Output to `stderr`* section in `docs/renderer/process-output.md` with a verified recipe: pass `process.stderr` for both `ProcessOutput` slots, set `forceTTY: true` (piping `stdout` makes it non-`TTY`, which would otherwise step _Listr_ down to the fallback renderer), and put the logger on both `rendererOptions` and `fallbackRendererOptions`.

Verified end to end — the live UI renders to `stderr` while `stdout` carries only the program's own output.

Two commits (fix + docs). Keep squash **off** so both survive. Targets `beta`.

closes K-723
refs #716