### PR TITLE
feat(lib): reset a task's streamed output when set to null

### DIFF
--- a/docs/task/output.md
+++ b/docs/task/output.md
@@ -46,6 +46,24 @@ Since observables and streams are supported they can also be used to generate ou
 
 :::
 
+### Reset the Output <Version version="v11.0.0" /><GithubIssue :issue="703" />
+
+Setting the output to `null` clears whatever the _Task_ has already streamed instead of rendering anything new.
+
+```typescript
+task.output = 'I will push an output.'
+
+task.output = null
+```
+
+For _DefaultRenderer_ this empties the output bar and the bottom bar for that _Task_, so a following `{ persistentOutput: true }` finalize keeps nothing. The append-only loggers, _SimpleRenderer_, _VerboseRenderer_, and _TestRenderer_, ignore it since their history can not be cleared.
+
+::: warning
+
+Prior to this, `task.output = null` used to render the literal string `"null"`.
+
+:::
+
 ## Render a WritableStream Directly
 
 <Version version="v2.1.0" /><GithubIssue :issue="31" />

--- a/examples/task-output.example.ts
+++ b/examples/task-output.example.ts
@@ -186,6 +186,39 @@ try {
   logger.log(ListrLogLevels.FAILED, e)
 }
 
+logger.log(ListrLogLevels.STARTED, 'Example resetting the streamed output of a task.')
+
+task = new Listr<Ctx>(
+  [
+    {
+      title: 'This task will execute.',
+      task: async(_, task): Promise<void> => {
+        task.output = 'I will push an output. [0]'
+        await delay(500)
+
+        task.output = 'I will push an output. [1]'
+        await delay(500)
+
+        task.output = null
+        await delay(500)
+
+        task.output = 'I will push an output. [2]'
+        await delay(500)
+      },
+      rendererOptions: { outputBar: Infinity, persistentOutput: true }
+    }
+  ],
+  { concurrent: false }
+)
+
+try {
+  const context = await task.run()
+
+  logger.log(ListrLogLevels.COMPLETED, ['ctx: %o', context])
+} catch(e: any) {
+  logger.log(ListrLogLevels.FAILED, e)
+}
+
 // SM8IHVdptzrFs7Qk2bseYbdCwtTf03QT
 logger.log(ListrLogLevels.STARTED, 'Example output from a observable.')
 

--- a/packages/listr2/src/constants/listr-task-events.constants.ts
+++ b/packages/listr2/src/constants/listr-task-events.constants.ts
@@ -20,6 +20,8 @@ export enum ListrTaskEventType {
   PROMPT = 'PROMPT',
   /** The current Task is now dumping output. */
   OUTPUT = 'OUTPUT',
+  /** The current Task has reset its streamed output. */
+  OUTPUT_RESET = 'OUTPUT_RESET',
   /**
    * The current Task is now dumping a message.
    *

--- a/packages/listr2/src/interfaces/listr-task-event-map.interface.ts
+++ b/packages/listr2/src/interfaces/listr-task-event-map.interface.ts
@@ -17,6 +17,7 @@ export declare class ListrTaskEventMap extends BaseEventMap implements EventMap<
   [ListrTaskEventType.SUBTASK]: Task<any, any, any>[];
   [ListrTaskEventType.TITLE]: string;
   [ListrTaskEventType.OUTPUT]: string;
+  [ListrTaskEventType.OUTPUT_RESET]: never;
   [ListrTaskEventType.MESSAGE]: ListrTaskMessage;
   [ListrTaskEventType.PROMPT]: string;
   [ListrTaskEventType.CLOSED]: never

--- a/packages/listr2/src/lib/task-wrapper.ts
+++ b/packages/listr2/src/lib/task-wrapper.ts
@@ -44,7 +44,13 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory, FallbackRen
    *
    * @see {@link https://listr2.kilic.dev/task/output.html}
    */
-  set output(output: string | any[]) {
+  set output(output: string | any[] | null) {
+    if (output === null) {
+      this.task.outputReset$ = null
+
+      return
+    }
+
     output = Array.isArray(output) ? output : [output]
 
     this.task.output$ = splat(output.shift(), ...output)

--- a/packages/listr2/src/lib/task.ts
+++ b/packages/listr2/src/lib/task.ts
@@ -110,6 +110,16 @@ export class Task<
   }
 
   /**
+   * Reset the current output of the Task and emit the neccassary events.
+   */
+  set outputReset$(data: null) {
+    this.output = data
+
+    this.emit(ListrTaskEventType.OUTPUT_RESET)
+    this.listr.events.emit(ListrEventType.SHOULD_REFRESH_RENDER)
+  }
+
+  /**
    * Update the current prompt output of the Task and emit the neccassary events.
    */
   set promptOutput$(data: string) {

--- a/packages/listr2/src/renderer/default/renderer.ts
+++ b/packages/listr2/src/renderer/default/renderer.ts
@@ -524,12 +524,13 @@ export class DefaultRenderer implements ListrRenderer {
         this.buffer.bottom.get(task.id).write(data.join(EOL))
       })
 
-      task.on(ListrTaskEventType.STATE, (state) => {
-        switch (state) {
-          case ListrTaskState.RETRY || ListrTaskState.ROLLING_BACK:
-            this.buffer.bottom.delete(task.id)
+      task.on(ListrTaskEventType.OUTPUT_RESET, () => {
+        this.buffer.bottom.get(task.id)?.reset()
+      })
 
-            break
+      task.on(ListrTaskEventType.STATE, (state) => {
+        if (state === ListrTaskState.RETRY || state === ListrTaskState.ROLLING_BACK) {
+          this.buffer.bottom.delete(task.id)
         }
       })
     } else if (this.shouldOutputToOutputBar(task) && !this.buffer.output.has(task.id)) {
@@ -539,12 +540,13 @@ export class DefaultRenderer implements ListrRenderer {
         this.buffer.output.get(task.id).write(output)
       })
 
-      task.on(ListrTaskEventType.STATE, (state) => {
-        switch (state) {
-          case ListrTaskState.RETRY || ListrTaskState.ROLLING_BACK:
-            this.buffer.output.delete(task.id)
+      task.on(ListrTaskEventType.OUTPUT_RESET, () => {
+        this.buffer.output.get(task.id)?.reset()
+      })
 
-            break
+      task.on(ListrTaskEventType.STATE, (state) => {
+        if (state === ListrTaskState.RETRY || state === ListrTaskState.ROLLING_BACK) {
+          this.buffer.output.delete(task.id)
         }
       })
     }

--- a/packages/listr2/tests/renderer/default/__snapshots__/output.e2e-spec.ts.snap
+++ b/packages/listr2/tests/renderer/default/__snapshots__/output.e2e-spec.ts.snap
@@ -1,5 +1,165 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`default renderer: output should be a no-op when output is cleared after the task has finalized: cthX0yZwrfeOdOxrvWGTZnCQrarUIuG3-exit 1`] = `[]`;
+
+exports[`default renderer: output should be a no-op when output is cleared after the task has finalized: cthX0yZwrfeOdOxrvWGTZnCQrarUIuG3-stderr 1`] = `[]`;
+
+exports[`default renderer: output should be a no-op when output is cleared after the task has finalized: cthX0yZwrfeOdOxrvWGTZnCQrarUIuG3-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[G[2K[G[2m◼[22m This task will execute.
+[K[?2026l",
+  "[?2026h[2K[1A[2K[1A[2K[G[33m❯[39m This task will execute.
+[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[1A[G[2K[1B[2K[1A[G  › I will push an output. [0]
+[2m◼[22m This task will execute.
+[K[?2026l",
+  "[?2026h[2K[1A[2K[1A[2K[1A[2K[G[32m✔[39m This task will execute.
+  › I will push an output. [0]
+[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[1A[G[2K[G[33m❯[39m This task will execute.[K
+[?2026l",
+  "[?2026h[1A[G[2K[G[32m✔[39m This task will execute.[K
+[?2026l",
+  "[?2026h[2K[1A[2K[1A[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+  › I will push an output. [0]
+[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should be a no-op when output is cleared before any output is streamed: J6xy27g81kBDTGYxfgOx6pwkGPmeNYHL-exit 1`] = `[]`;
+
+exports[`default renderer: output should be a no-op when output is cleared before any output is streamed: J6xy27g81kBDTGYxfgOx6pwkGPmeNYHL-stderr 1`] = `[]`;
+
+exports[`default renderer: output should be a no-op when output is cleared before any output is streamed: J6xy27g81kBDTGYxfgOx6pwkGPmeNYHL-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[32m✔[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as Infinity when output is set to null: 9Ol7Y5L4326KO4NFEpMpNHZuIEGJwR1N-exit 1`] = `[]`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as Infinity when output is set to null: 9Ol7Y5L4326KO4NFEpMpNHZuIEGJwR1N-stderr 1`] = `[]`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as Infinity when output is set to null: 9Ol7Y5L4326KO4NFEpMpNHZuIEGJwR1N-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [0]
+[K[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [1]
+[K[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [2]
+[K[?2026l",
+  "[?2026h[3A[G[2K[1B[2K[1B[2K[1B[2K[3A[G[K[?2026l",
+  "[?2026h[2K[1A[2K[G[32m✔[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as a number when output is set to null: PWHBuAjpZIwJ9XlrlYQTri847NT0RuKY-exit 1`] = `[]`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as a number when output is set to null: PWHBuAjpZIwJ9XlrlYQTri847NT0RuKY-stderr 1`] = `[]`;
+
+exports[`default renderer: output should clear all lines from the output bar with outputBar as a number when output is set to null: PWHBuAjpZIwJ9XlrlYQTri847NT0RuKY-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [0]
+[K[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [1]
+[K[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [2]
+[K[?2026l",
+  "[?2026h[3A[G[2K[1B[2K[1B[2K[1B[2K[3A[G[K[?2026l",
+  "[?2026h[2K[1A[2K[G[32m✔[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should clear the bottom bar when output is set to null: X9WByECJDy84XWuHMs8djxYdkWQEZpIa-exit 1`] = `[]`;
+
+exports[`default renderer: output should clear the bottom bar when output is set to null: X9WByECJDy84XWuHMs8djxYdkWQEZpIa-stderr 1`] = `[]`;
+
+exports[`default renderer: output should clear the bottom bar when output is set to null: X9WByECJDy84XWuHMs8djxYdkWQEZpIa-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[1B[G[G› I will push an output. [0]
+[K[?2026l",
+  "[?2026h[G[2K[G› I will push an output. [1]
+[K[?2026l",
+  "[?2026h[G[2K[G› I will push an output. [2]
+[K[?2026l",
+  "[?2026h[3A[G[2K[1B[2K[1B[2K[1B[2K[3A[G[1A[?2026l",
+  "[?2026h[2K[1A[2K[G[32m✔[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should clear the output bar when output is set to null: NduelZU7RnrfhxPfeXiFeQhYBm9bIRKW-exit 1`] = `[]`;
+
+exports[`default renderer: output should clear the output bar when output is set to null: NduelZU7RnrfhxPfeXiFeQhYBm9bIRKW-stderr 1`] = `[]`;
+
+exports[`default renderer: output should clear the output bar when output is set to null: NduelZU7RnrfhxPfeXiFeQhYBm9bIRKW-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [0]
+[K[?2026l",
+  "[?2026h[1A[G[2K[G  › I will push an output. [1][K
+[?2026l",
+  "[?2026h[1A[G[2K[1B[2K[1A[G[K[?2026l",
+  "[?2026h[2K[1A[2K[G[32m✔[39m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
 exports[`default renderer: output should have persistent output on task fail with bottom bar false: MjcoXTjPbNRDsgOIbGzvjt7MEaZcmasv-exit 1`] = `[]`;
 
 exports[`default renderer: output should have persistent output on task fail with bottom bar false: MjcoXTjPbNRDsgOIbGzvjt7MEaZcmasv-stderr 1`] = `[]`;
@@ -434,6 +594,33 @@ exports[`default renderer: output should output to output bar with last output: 
 [?2026l",
   "[?2026h[2K[1A[2K[G[?2026l",
   "[32m✔[39m This task will execute.
+",
+  "[?25h",
+]
+`;
+
+exports[`default renderer: output should stream new output again after being cleared with null: W8PPqm0hMrdkqJZ46wdFJdFbHnpQIV71-exit 1`] = `[]`;
+
+exports[`default renderer: output should stream new output again after being cleared with null: W8PPqm0hMrdkqJZ46wdFJdFbHnpQIV71-stderr 1`] = `[]`;
+
+exports[`default renderer: output should stream new output again after being cleared with null: W8PPqm0hMrdkqJZ46wdFJdFbHnpQIV71-stdout 1`] = `
+[
+  "[?25l",
+  "[?2026h[2m◼[22m This task will execute.
+[?2026l",
+  "[?2026h[2K[1A[2K[G[33m❯[39m This task will execute.
+[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [0]
+[K[?2026l",
+  "[?2026h[1A[G[2K[1B[2K[1A[G[K[?2026l",
+  "[?2026h[G[2K[G  › I will push an output. [1]
+[K[?2026l",
+  "[?2026h[2K[1A[2K[1A[2K[G[32m✔[39m This task will execute.
+  › I will push an output. [1]
+[?2026l",
+  "[?2026h[2K[1A[2K[1A[2K[G[?2026l",
+  "[32m✔[39m This task will execute.
+  › I will push an output. [1]
 ",
   "[?25h",
 ]

--- a/packages/listr2/tests/renderer/default/output.e2e-spec.ts
+++ b/packages/listr2/tests/renderer/default/output.e2e-spec.ts
@@ -353,4 +353,188 @@ describe('default renderer: output', () => {
 
     expectProcessOutputToMatchSnapshot(output, 'MjcoXTjPbNRDsgOIbGzvjt7MEaZcmasv')
   })
+
+  // NduelZU7RnrfhxPfeXiFeQhYBm9bIRKW
+  it('should clear the output bar when output is set to null', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            task.output = 'I will push an output. [1]'
+
+            task.output = null
+          },
+          rendererOptions: { outputBar: true, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'NduelZU7RnrfhxPfeXiFeQhYBm9bIRKW')
+  })
+
+  // 9Ol7Y5L4326KO4NFEpMpNHZuIEGJwR1N
+  it('should clear all lines from the output bar with outputBar as Infinity when output is set to null', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            task.output = 'I will push an output. [1]'
+
+            task.output = 'I will push an output. [2]'
+
+            task.output = null
+          },
+          rendererOptions: { outputBar: Infinity, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, '9Ol7Y5L4326KO4NFEpMpNHZuIEGJwR1N')
+  })
+
+  // PWHBuAjpZIwJ9XlrlYQTri847NT0RuKY
+  it('should clear all lines from the output bar with outputBar as a number when output is set to null', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            task.output = 'I will push an output. [1]'
+
+            task.output = 'I will push an output. [2]'
+
+            task.output = null
+          },
+          rendererOptions: { outputBar: 3, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'PWHBuAjpZIwJ9XlrlYQTri847NT0RuKY')
+  })
+
+  // X9WByECJDy84XWuHMs8djxYdkWQEZpIa
+  it('should clear the bottom bar when output is set to null', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            task.output = 'I will push an output. [1]'
+
+            task.output = 'I will push an output. [2]'
+
+            task.output = null
+          },
+          rendererOptions: { bottomBar: Infinity, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'X9WByECJDy84XWuHMs8djxYdkWQEZpIa')
+  })
+
+  // W8PPqm0hMrdkqJZ46wdFJdFbHnpQIV71
+  it('should stream new output again after being cleared with null', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            task.output = null
+
+            task.output = 'I will push an output. [1]'
+          },
+          rendererOptions: { outputBar: Infinity, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'W8PPqm0hMrdkqJZ46wdFJdFbHnpQIV71')
+  })
+
+  // J6xy27g81kBDTGYxfgOx6pwkGPmeNYHL
+  it('should be a no-op when output is cleared before any output is streamed', async() => {
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = null
+          },
+          rendererOptions: { outputBar: Infinity, persistentOutput: true }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'J6xy27g81kBDTGYxfgOx6pwkGPmeNYHL')
+  })
+
+  // cthX0yZwrfeOdOxrvWGTZnCQrarUIuG3
+  it('should be a no-op when output is cleared after the task has finalized', async() => {
+    let finalized: any
+
+    await new Listr(
+      [
+        {
+          title: 'This task will execute.',
+          task: async(_, task): Promise<void> => {
+            task.output = 'I will push an output. [0]'
+
+            finalized = task
+          },
+          rendererOptions: { outputBar: Infinity, persistentOutput: true }
+        },
+
+        {
+          title: 'This task will execute.',
+          task: async(): Promise<void> => {
+            finalized.output = null
+          }
+        }
+      ],
+      {
+        concurrent: false,
+        rendererOptions: { lazy: true }
+      }
+    ).run()
+
+    expectProcessOutputToMatchSnapshot(output, 'cthX0yZwrfeOdOxrvWGTZnCQrarUIuG3')
+  })
 })


### PR DESCRIPTION
## Summary

Resettable task output — the clean version of the concept in community PR #704 (GitHub #703), designed from the current code.

Setting `task.output = null` now explicitly **clears** a task's streamed output in the _DefaultRenderer_ — the output bar and the task's bottom-bar entries — instead of rendering the literal string `"null"`. It emits a dedicated `OUTPUT_RESET` task event that the renderer resets its `ProcessOutputBuffer` on; the append-only _SimpleRenderer_ / _VerboseRenderer_ / _TestRenderer_ ignore it (their history can't be cleared). `persistentOutput` is unaffected — clear-then-finalize persists nothing.

Also folds in an adjacent renderer bug fix: the `RETRY` / `ROLLING_BACK` buffer-clear only ran for `RETRY` (the `case A || B` label evaluated to `RETRY` alone), so a rollback never cleared its output buffer.

Covered by new cases in the default-renderer output e2e spec (clear with `outputBar` `true` / number / `Infinity`, bottom bar, stream-again-after-reset, clear-before-output and clear-after-finalize no-ops), documented in `docs/task/output.md`, with a runnable example.

Targets `beta`.

closes K-722
refs #703