### PR TITLE
docs: overhaul documentation — accuracy, anchors, gaps, and llms API exclusion

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,6 +120,8 @@ build-docs:
   variables:
     NODE_COMMAND_SCRIPT: docs:build
     NODE_COMMAND_CWD: ./docs
+    # full history so VitePress `lastUpdated` reflects each file's real last commit, not a shallow-clone uniform date
+    GIT_DEPTH: '0'
   artifacts:
     paths:
       - ./docs/dist

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -82,7 +82,7 @@ export default defineConfig({
       sortMenusByFrontmatterOrder: true,
       capitalizeFirst: true,
       collapsed: true,
-      excludePattern: ['format.md', 'node_modules/**'],
+      excludePattern: ['format.md', 'node_modules/**', 'dist/**'],
       manualSortFileNameByPriority: ['repository', 'listr', 'task', 'renderer', 'migration', 'api']
     }) as any,
     socialLinks: [{ icon: 'github', link: 'https://github.com/listr2/listr2' }]

--- a/docs/format.md
+++ b/docs/format.md
@@ -7,13 +7,13 @@ order: 0
 
 <!-- included code snippet -->
 
-<<< @../../examples/docs/task/subtasks/overwriting-options.ts{9,24}
+<<< @../../examples/docs/task/subtasks/overwriting-options.ts{8,23}
 
 <!-- collapsed code snippet-->
 
 ::: details <CodeExampleIcon /> Code Example
 
-@[code{4-} typescript{9,24,31,46,50}](../../examples/docs/task/subtasks/overwriting-options.ts)
+<<< @../../examples/docs/task/subtasks/overwriting-options.ts{8,23,30,45,49}
 
 :::
 
@@ -35,8 +35,12 @@ You can find the related examples [here](https://github.com/listr2/listr2/tree/m
 
 <!-- include details -->
 
+<llm-exclude>
+
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{156-186} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{124,148} -->
 
 :::
+
+</llm-exclude>

--- a/docs/listr/context.md
+++ b/docs/listr/context.md
@@ -25,7 +25,7 @@ Context type can be injected as a type parameter to Listr class to limit what is
 
 - A successful task will return the context for further operation.
 - Context can be injected from outside while creating the task list or running the task list.
-- If an error is encountered, the context at the time will be recorded as a frozen object to give the ability to further debug the issue.
+- If an error is encountered, the failed `task` is available on the collected `ListrError` for further debugging; the context itself is no longer attached.
 
 You can also manually inject a context variable default in multiple ways.
 
@@ -41,7 +41,7 @@ If all tasks are in the same task list, the context will be automatically inject
 
 Context can be injected as an option to the _Listr_.
 
-<<< @../../examples/docs/listr/context/as-option.ts{9}
+<<< @../../examples/docs/listr/context/as-option.ts
 
 #### Multiple Contexts <GithubIssue :issue="612" />
 
@@ -55,7 +55,7 @@ This can also be used to inject a different context into subtasks. Imagine that 
 
 ### Injecting Context at Runtime
 
-<<< @../../examples/docs/listr/context/at-runtime.ts{8}
+<<< @../../examples/docs/listr/context/at-runtime.ts
 
 ## Retrieving Context
 

--- a/docs/listr/environment.md
+++ b/docs/listr/environment.md
@@ -18,6 +18,6 @@ order: 10
 
 Thanks to [@hyperz111](https://github.com/hyperz111) for making me aware of this change, which cut our bundle distribution size in half.
 
-Given the latest changes on `ts-node`, `jest`, and `ts-jest` allowed us to move everything in the repository to `esm`. This enabled the repository starting from version <Version version="v6" /> to use dynamic imports for anything that is using an `esm` module. So from that version and upward, everything should be up to date with the upstream of the dependencies. So keeping the `cjs` version does not hinder us from updating the given packages.
+Recent changes to `ts-node`, `jest`, and `ts-jest` let us move the entire repository to `esm`. This enabled the repository starting from version <Version version="v6" /> to use dynamic imports for anything that is using an `esm` module. So from that version and upward, everything should be up to date with the upstream of the dependencies. So keeping the `cjs` version does not hinder us from updating the given packages.
 
 > The community is moving to pure `esm` modules. [sindresorhus](https://github.com/sindresorhus) who is the maintainer of many-core `npm` packages ([cheers!](https://github.com/sponsors/sindresorhus) ) has to lead the movement with the deprecated `node.js` `10` support. You can read more about it [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) in his post.

--- a/docs/listr/examples.md
+++ b/docs/listr/examples.md
@@ -15,7 +15,7 @@ Examples live in the folder [`./examples/`](https://github.com/listr2/listr2/tre
 
 The documentation also includes many examples, these examples are also working examples that can be run/inspected in the folder [`./examples/docs/`](https://github.com/listr2/listr2/tree/master/examples/docs).
 
-If you ever choose to clone the repository, you can run all the examples through `ts-node` in your local environment, to learn about or test new things out.
+If you ever choose to clone the repository, you can run all the examples locally with the `pnpm run --filter @listr2/examples start` script, to learn about or test new things out.
 
 ```bash
 # clone the repository
@@ -28,7 +28,7 @@ pnpm install
 pnpm build
 
 # run any example, by giving the script a relative path in the repository
-pnpm run --filter examples start examples/renderer-default.example.ts
+pnpm run --filter @listr2/examples start examples/renderer-default.example.ts
 ```
 
 ## `jsdoc`

--- a/docs/listr/interruption.md
+++ b/docs/listr/interruption.md
@@ -1,6 +1,6 @@
 ---
 title: Interruption
-order: 30
+order: 110
 ---
 
 # {{ $frontmatter.title }}

--- a/docs/listr/manager.md
+++ b/docs/listr/manager.md
@@ -46,4 +46,4 @@ pnpm i @listr2/manager
 
 The idea of having an additional task manager is to create a higher-order factory to create _Listr_ on demand with always your options. This allows you to not store your options as variables that you inject every time you create a new _Listr_ but store it in a stateful Manager where you can initiate as many _Listr_ task lists as you want.
 
-It can alternatively be used as a single-task list for ongoing actions where you can add more tasks as you like. This is also possible through _Listr_ but not as convenient to do.
+It can alternatively be used as a running task list for ongoing actions, where you add more tasks over time through `manager.add()`. This is also possible with a plain _Listr_, but less convenient.

--- a/docs/listr/manager.md
+++ b/docs/listr/manager.md
@@ -47,3 +47,48 @@ pnpm i @listr2/manager
 The idea of having an additional task manager is to create a higher-order factory to create _Listr_ on demand with always your options. This allows you to not store your options as variables that you inject every time you create a new _Listr_ but store it in a stateful Manager where you can initiate as many _Listr_ task lists as you want.
 
 It can alternatively be used as a running task list for ongoing actions, where you add more tasks over time through `manager.add()`. This is also possible with a plain _Listr_, but less convenient.
+
+## Usage
+
+### Creating a Manager
+
+Create the _Manager_ once with the base options every list should share, then reuse it. Wrapping it in a factory keeps the preset in a single place.
+
+```typescript
+import { Manager } from '@listr2/manager'
+import type { ListrBaseClassOptions } from 'listr2'
+
+function TaskManagerFactory<Ctx = any>(override?: ListrBaseClassOptions<Ctx>): Manager<Ctx> {
+  return new Manager({ concurrent: false, exitOnError: false, ...override })
+}
+```
+
+### Creating a List on Demand
+
+`manager.newListr(tasks, options?)` returns a normal [_Listr_](/listr/listr.html) instance built with the manager's preset options, which you then run yourself. Per-call `options` are merged over the preset.
+
+```typescript
+const manager = TaskManagerFactory()
+
+const list = manager.newListr([{ title: 'A task', task: async (): Promise<void> => {} }])
+await list.run()
+```
+
+### Queueing and Running
+
+`manager.add(tasks, options?)` appends to an internal queue instead of running immediately — each `add()` becomes its own indented group. `manager.runAll(options?)` then runs everything queued and clears the queue. `add()` also accepts a function that receives the context, so a group can be built lazily from the state produced by earlier groups.
+
+```typescript
+manager.add([{ title: 'First group', task: async (): Promise<void> => {} }])
+manager.add((ctx) => [{ title: 'Built from context', task: async (): Promise<void> => {} }])
+
+const ctx = await manager.runAll()
+```
+
+### Running Once
+
+`manager.run(tasks, options?)` builds and runs a one-off list with the preset options in a single call — the immediate counterpart to `newListr` followed by `run`.
+
+### Shared Context and Errors
+
+Seed the context passed to every list the manager creates through `manager.ctx`. Errors collected from each run — when `collectErrors` is enabled — accumulate on `manager.errors` across the manager's lifetime.

--- a/docs/renderer/custom.md
+++ b/docs/renderer/custom.md
@@ -36,9 +36,11 @@ Take a look at _DefaultRenderer_ since it is implemented this way.
 
 ## Utilizing the Events
 
-_Listr_ and its _Task_ fires many events to indicate the task status. _Task_ depending on what is currently done will fire [ListrTaskState](/api/listr2/enumerations/ListrTaskState.html) and [ListrTaskEventType](/api/listr2/enumerations/ListrTaskEventType.html) through [ListrTaskEventManager](/api/listr2/classes/ListrTaskEventManager.html) which you can subscribe.
+_Listr_ and its _Task_ fires many events to indicate the task status. _Task_ depending on what is currently done will fire [ListrTaskState](/api/listr2/enumerations/ListrTaskState.html) and [ListrTaskEventType](/api/listr2/enumerations/ListrTaskEventType.html) through [ListrTaskEventManager](/api/listr2/classes/ListrTaskEventManager.html) which you can subscribe to.
 
 Take a look at _SimpleRenderer_ or _VerboseRenderer_ since it is implemented this way.
+
+A renderer that buffers per-task output — as the _DefaultRenderer_ does for its output bar and bottom bar — subscribes to the individual _Task_ through `task.on(...)`, reacting to [`ListrTaskEventType`](/api/listr2/enumerations/ListrTaskEventType.html) events such as `OUTPUT`, `OUTPUT_RESET`, `STATE` and `PROMPT`.
 
 ::: details <CodeExampleIcon /> Code Example
 
@@ -56,7 +58,7 @@ Take a look at _SimpleRenderer_ or _VerboseRenderer_ since it is implemented thi
 
 <Version version="v2.1.0" />
 
-Additional to listening to the events, another singleton hook that come from the root _Listr_ is `events`. This provides some generic events like [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/ListrEventType.html#should-refresh-render) which can be used to trigger an update on an updating renderer.
+Additional to listening to the events, another singleton hook that comes from the root _Listr_ is `events`. This provides some generic events like [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/ListrEventType.html#should-refresh-render) which can be used to trigger an update on an updating renderer.
 
 These `events` can be the third optional variable of a given renderer while using it is always optional.
 

--- a/docs/renderer/default.md
+++ b/docs/renderer/default.md
@@ -13,13 +13,21 @@ _DefaultRenderer_ is the main renderer of `listr2`.
 
 <!-- more -->
 
-_DefaultRenderer_ is intended for `TTY` environments with `vt100` terminal compatibility, where it updates the current update constantly depending on the changes in _Task_. This renderer has many options for customization, these options can be changed at _Listr_, _Subtask_ or _Task_ level.
+_DefaultRenderer_ is intended for `TTY` environments with `vt100` terminal compatibility, where it continuously redraws the terminal output as the state of a _Task_ changes. This renderer has many options for customization, these options can be changed at _Listr_, _Subtask_ or _Task_ level.
 
 This renderer uses _ProcessOutput_ to take control of the terminal.
 
 ![demo](../../examples/renderer-default.gif)
 
+## How Updates Are Rendered
+
+<Version version="v11.0.0" />
+
+The task list is drawn with partial, differential updates through [`log-update`](https://www.npmjs.com/package/log-update) `v8`. Instead of clearing and rewriting the whole screen on every change, only the lines that actually changed are rewritten, and each redraw is wrapped in synchronized-output markers (`ESC[?2026h`/`ESC[?2026l`) on supporting terminals to reduce flicker. The visible result is identical to previous versions, only smoother.
+
 ## Renderer Options
+
+<llm-exclude>
 
 ::: details
 
@@ -27,10 +35,16 @@ This renderer uses _ProcessOutput_ to take control of the terminal.
 
 :::
 
+</llm-exclude>
+
 ## Renderer Task Options
+
+<llm-exclude>
 
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrDefaultRendererTaskOptions.md -->
 
 :::
+
+</llm-exclude>

--- a/docs/renderer/logger.md
+++ b/docs/renderer/logger.md
@@ -44,9 +44,13 @@ The `icon` and `color` section of the supported renderer is in the form of [List
 
 <Version version="v6.0.0" />
 
-_ListrLogger_ can have fields for each entry in the form of prefixes and suffixes.
+_ListrLogger_ can wrap each entry with fields in the form of prefixes and suffixes through `logger.prefix(message, ...fields)` and `logger.suffix(message, ...fields)`. A field is either a plain `string` or a [`LoggerField`](/api/listr2/type-aliases/LoggerField.html) object, which can compute its value from arguments, render conditionally, and carry its own formatting.
 
-Please refer to the _presets_ section for how to use this with the renderers.
+```typescript
+logger.suffix('a message', { field: () => new Date().toISOString(), condition: showTimestamp })
+```
+
+The [presets](#presets) below are prebuilt fields — timers and timestamps — that plug into this same prefix/suffix mechanism.
 
 ## Presets
 

--- a/docs/renderer/process-output.md
+++ b/docs/renderer/process-output.md
@@ -24,6 +24,10 @@ category:
 
 After the renderer releases the _ProcessOutput_ and marks it ready to use, everything that has been outputted to the hooked streams will be dumped. **This intends to solve the most common cause of opening an issue in the repository which is saying that the output is corrupted and not realizing something else is writing to output the terminal.**
 
+## Writing Through Process Output
+
+When you write your own renderer or logger, emit through the _ProcessOutput_ instead of touching `process.stdout` directly, so your output stays coordinated with the hijack/release cycle. `output.toStdout(buffer)` and `output.toStderr(buffer)` write to the correct stream, and the underlying streams are also reachable through `output.stream`.
+
 ## Extending Process Output
 
 You can override the default _ProcessOutput_ by extending the class with your expected behavior (e.g. writing to a log file) on the _ListrLogger_ since all the renderers, that either use or do not use the hijacking function, use _ProcessOutput_ through _ListrLogger_ itself. For most cases, just creating a `new ProcessOutput()` by passing your own `WriteStream` for `process.stdout` and `process.stderr` through the constructor should be good enough.

--- a/docs/renderer/renderer.md
+++ b/docs/renderer/renderer.md
@@ -13,7 +13,7 @@ Renderers are the communication interface with your _Listr_.
 
 <!-- more -->
 
-There are five main renderers, which are `default`, `simple`, `verbose`, and `silent` as well as a testing renderer called `test`.
+There are five renderers: `default`, `simple`, `verbose`, `silent`, and the testing-only `test`.
 
 _DefaultRenderer_ is the default choice.
 

--- a/docs/renderer/simple.md
+++ b/docs/renderer/simple.md
@@ -19,16 +19,24 @@ _SimpleRenderer_ still requires `vt100` terminal compatibility if you are using 
 
 ## Renderer Options
 
+<llm-exclude>
+
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrSimpleRendererOptions.md -->
 
 :::
 
+</llm-exclude>
+
 ## Renderer Task Options
+
+<llm-exclude>
 
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrSimpleRendererTaskOptions.md -->
 
 :::
+
+</llm-exclude>

--- a/docs/renderer/test.md
+++ b/docs/renderer/test.md
@@ -18,8 +18,12 @@ This JSON format specific can be seen [here](/api/listr2/interfaces/TestRenderer
 
 ## Renderer Options
 
+<llm-exclude>
+
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrTestRendererOptions.md -->
 
 :::
+
+</llm-exclude>

--- a/docs/renderer/verbose.md
+++ b/docs/renderer/verbose.md
@@ -9,7 +9,7 @@ category:
 
 # {{ $frontmatter.title }}
 
-_VerboseRenderer_ is the default `non-TTY` renderer and works mostly like a logger.
+_VerboseRenderer_ was the default `non-TTY` renderer prior to <Version version="v6.0.0" /> and works mostly like a logger.
 
 <!-- more -->
 
@@ -17,16 +17,24 @@ _VerboseRenderer_ is the default `non-TTY` renderer and works mostly like a logg
 
 ## Renderer Options
 
+<llm-exclude>
+
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrVerboseRendererOptions.md -->
 
 :::
 
+</llm-exclude>
+
 ## Renderer Task Options
+
+<llm-exclude>
 
 ::: details
 
 <!-- @include: ../api/listr2/interfaces/ListrVerboseRendererTaskOptions.md -->
 
 :::
+
+</llm-exclude>

--- a/docs/repository/changelog.md
+++ b/docs/repository/changelog.md
@@ -11,4 +11,9 @@ next: false
 
 <!-- more -->
 
-<!-- @include: ../../packages/listr2/CHANGELOG.md -->
+The changelog for each published package is maintained on GitHub — jump to the one you need:
+
+- [`listr2`](https://github.com/listr2/listr2/blob/master/packages/listr2/CHANGELOG.md)
+- [`@listr2/manager`](https://github.com/listr2/listr2/blob/master/packages/manager/CHANGELOG.md)
+- [`@listr2/prompt-adapter-enquirer`](https://github.com/listr2/listr2/blob/master/packages/prompt-adapter-enquirer/CHANGELOG.md)
+- [`@listr2/prompt-adapter-inquirer`](https://github.com/listr2/listr2/blob/master/packages/prompt-adapter-inquirer/CHANGELOG.md)

--- a/docs/repository/contributions.md
+++ b/docs/repository/contributions.md
@@ -19,25 +19,7 @@ You can always open up a new issue for reporting the bugs and requesting feature
 
 ## Looking for Contributions
 
-This section implies the following features or bug fixes are blocked for some reason or other and would be more than happy for any contributiors.
-
-### Updating Renderer
-
-Swapping updating renderer [`log-update`](https://www.npmjs.com/package/log-update) for another library where it can do partial updates.
-
-#### Problems with Current Implementation
-
-- For sufficiently long task lists, the flashing effect happens due to it updating the whole screen whenever [`ListrEventType.SHOULD_REFRESH_RENDER`](/api/listr2/enumerations/ListrEventType.html#should-refresh-render) is triggered by the parent task indicating a new render should be done.
-- Most of the issues are opened about _Listr_ breaking or corrupting the terminal output. This sometimes causes unintended behavior.
-- It brings a lot of overhead of wrapping and truncating the lines again inside the default renderer since the built-in one does not seem to work for our case.
-
-#### What has been done?
-
-There are a couple of tries have been made to migrate using the library [`stdout-update`](https://www.npmjs.com/package/stdout-update).
-
-This has been mostly failed tries due to it behaving strangely on some tests.
-
-Naturally, we do not expect it to be a one-to-one replacement, but some tests failed to generate any kind of output at all.
+This section implies the following features or bug fixes are blocked for some reason or other and would be more than happy for any contributors.
 
 ### Progress Bar
 

--- a/docs/repository/release.md
+++ b/docs/repository/release.md
@@ -30,7 +30,7 @@ After migrating `ts-node`, `jest`, `ts-jest` to `esm` as well in the repository 
 
 - A new version will be published whenever a production dependency is updated.
 - Major dependencies require accepting the pull requests manually.
-- Every CI rule that this repository employs will run before updating any dependency. So if something fails the tests, it will not be merged in. Till now it has never been an instance where garbage/unworking code has been published with this methodology, so it is not much of a wory.
+- Every CI rule that this repository employs will run before updating any dependency. So if something fails the tests, it will not be merged in. Till now it has never been an instance where garbage/unworking code has been published with this methodology, so it is not much of a worry.
 - This is running on my Gitlab instance, so you can not directly see the changes/requests in Github. It can only be inspected further through the public pipelines or changelog after the fact.
 
 ## Hooks

--- a/docs/task/error-handling.md
+++ b/docs/task/error-handling.md
@@ -69,15 +69,19 @@ Be aware that the execution will only stop after the error is thrown out. This c
 
 Default renderer has options where you can change how the errors are displayed.
 
+<llm-exclude>
+
 ::: details Interface
 
-<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{225,259} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{203,233} -->
 
 :::
 
+</llm-exclude>
+
 ## Collected Errors
 
-Errors from the _Task_ are collected inside an array in the main _Listr_ task list as `tasks.error` where `tasks` is the _Listr_ class. **This option is opt-in since <Version version="v6.0.0" />.**
+Errors from the _Task_ are collected inside an array in the main _Listr_ task list as `tasks.errors` where `tasks` is the _Listr_ class. **This option is opt-in since <Version version="v6.0.0" />.**
 
 Since there are options to ignore some errors on cases like `exitOnError`, or the ability to retry the given task through `task.retry`, encountered errors can be swallowed while the execution. To deal with those swallowed errors, all the errors that are encountered even though it does not stops the execution gets collected through this property.
 
@@ -99,9 +103,17 @@ While collection is disabled, `Listr.errors` is `null` instead of an empty array
 
 A listr error can be caused by multiple reasons, for a better explanation of why that particular error occurred, a type property on the `ListrError` exists in the form of enum [`ListrErrorTypes`](/api/listr2/enumerations/ListrErrorTypes.html).
 
+### Reporting an Error Manually
+
+A _Task_ can attach an error to the collection without throwing or interrupting its own execution through `task.report(error, type)`, where `type` is one of [`ListrErrorTypes`](/api/listr2/enumerations/ListrErrorTypes.html). This is handy when a task recovers from a failure but you still want it recorded. The error is only stored while `collectErrors` is enabled.
+
+```typescript
+task.report(new Error('recovered, but worth noting'), ListrErrorTypes.HAS_FAILED)
+```
+
 ### Methodology
 
-The order of the array `tasks.error` where `tasks` is the _Listr_ class, represents the order of errors that are encountered.
+The order of the array `tasks.errors` where `tasks` is the _Listr_ class, represents the order of errors that are encountered.
 
 To keep the error collection mechanism simple and predictable, it might also process the errors coming from the subtasks as well.
 
@@ -121,7 +133,7 @@ For example, the following example will clear some things up about the given min
 
 ::: details Flow
 
-- First error will be thrown from the first task. Since exitOnError is `false` on that context, `ListrError` will get collected by `tasks.errors`], and the value will be `{ message: '1', type: ListrErrorTypes.HAS_FAILED_WITHOUT_ERROR }`.
+- First error will be thrown from the first task. Since exitOnError is `false` on that context, `ListrError` will get collected by `tasks.errors`, and the value will be `{ message: '1', type: ListrErrorTypes.HAS_FAILED_WITHOUT_ERROR }`.
 - Then it will recurse into the second task, which has two subtasks.
 - The first task from the subtasks will fail and since the `exitOnError` is set to `true` in that context, that subtasks will fail and throw. The `ListrError` appended to the `tasks.errors` will be `{ message: '3', type: ListrErrorTypes.HAS_FAILED }`
 - Since the subtask has crashed, it will not execute the upcoming tasks in the subtasks.

--- a/docs/task/error-handling.md
+++ b/docs/task/error-handling.md
@@ -79,6 +79,10 @@ Default renderer has options where you can change how the errors are displayed.
 
 </llm-exclude>
 
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers log a `FAILED` entry carrying the error message.
+
 ## Collected Errors
 
 Errors from the _Task_ are collected inside an array in the main _Listr_ task list as `tasks.errors` where `tasks` is the _Listr_ class. **This option is opt-in since <Version version="v6.0.0" />.**

--- a/docs/task/output.md
+++ b/docs/task/output.md
@@ -139,3 +139,7 @@ To keep the output after the task has been completed while using the default ren
 <<< @../../examples/docs/task/output/renderer-default-persistent.ts
 
 :::
+
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers have no bars. Every line written to `task.output` is logged as an `OUTPUT` entry as it arrives, interleaved with the rest of the log, so the output is inherently persistent — the `outputBar`, `bottomBar` and `persistentOutput` options do not apply.

--- a/docs/task/output.md
+++ b/docs/task/output.md
@@ -68,7 +68,7 @@ Prior to this, `task.output = null` used to render the literal string `"null"`.
 
 <Version version="v2.1.0" /><GithubIssue :issue="31" />
 
-`process.stdout` and `process.stderr` might get hooked depending on the usage of _ProcessOutput_ on the selected renderer. So anything that requires a `WritableStream` while the task running to dump the output, should go through the _Listr_ itself by creating a temporary `WritableStream` with `task.stdout()`.
+`process.stdout` and `process.stderr` might get hooked depending on the usage of _ProcessOutput_ on the selected renderer. So anything that requires a `WritableStream` while the task is running to dump the output should go through `task.stdout()`, which creates a temporary `WritableStream` for the task, instead of writing to the stream directly.
 
 ## Render Output of a Command
 

--- a/docs/task/prompts.md
+++ b/docs/task/prompts.md
@@ -58,7 +58,7 @@ Since _Task_ keeps track of the active prompt and this adapter exposes a `cancel
 
 ::: warning
 
-`inquirer` acts a little bit different while canceling the prompt, since it is a implemented in a `CancellablePromise` kind of way and not exposing submit externally, whenever the promise is cancelled it will throw an error out from the promise.
+`inquirer` acts a little bit different while canceling the prompt, since it is implemented as a `CancellablePromise` that does not expose `submit` externally; cancelling the promise throws an error out of it.
 
 :::
 
@@ -140,7 +140,7 @@ As a convenience, whenever you have just one prompt, you do not have to name you
 
 ::: warning
 
-If you want to pass in an array of prompts, be careful that you should name them, this is also enforced by Typescript as well. This is not true for single prompts, since they only return a single value, it will be direct gets past to the assigned variable.
+If you want to pass in an array of prompts, be careful that you should name them, this is also enforced by Typescript as well. This is not true for single prompts, since they only return a single value that is passed directly to the assigned variable.
 
 :::
 
@@ -156,7 +156,7 @@ import EditorPrompt from 'enquirer-editor'
 import { Listr, ListrEnquirerPromptAdapter } from 'listr2'
 
 const enquirer = new Enquirer()
-enquirer.register('editor', Editor)
+enquirer.register('editor', EditorPrompt)
 
 const tasks = new Listr<Ctx>(
   [

--- a/docs/task/retry.md
+++ b/docs/task/retry.md
@@ -63,3 +63,7 @@ Retrying is self-aware, and you can access the task if it is retrying via `task.
 :::
 
 </llm-exclude>
+
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers log a `RETRY` entry with the current attempt count on each retry, rather than resetting an in-place title.

--- a/docs/task/retry.md
+++ b/docs/task/retry.md
@@ -34,9 +34,11 @@ Retry action can have a delay between the tries. For enabling this behavior, you
 
 <<< @../../examples/docs/task/retry/retry-delay.ts{18-21}
 
+While waiting between attempts the task enters a paused state, and the _DefaultRenderer_ shows a live countdown until the next try through its `pausedTimer` option. You can check for this state inside a task with `task.isPaused()`.
+
 ## Retry Event
 
-Retrying is self-aware, and you can access the task if it is retrying via `task.isRetrying()`. It will either return an object [with the given interface](/api/listr2/interfaces/ListrTaskRetry.html) where the `count` will be `0` for not repeating tasks, and `withError` is the last encountered error if retrying.
+Retrying is self-aware, and you can access the task if it is retrying via `task.isRetrying()`. It will either return an object [with the given interface](/api/listr2/interfaces/ListrTaskRetry.html) where the `count` will be `0` for not repeating tasks, and `error` is the last encountered error if retrying.
 
 ### Retry Count
 
@@ -52,8 +54,12 @@ Retrying is self-aware, and you can access the task if it is retrying via `task.
 
 ### _DefaultRenderer_
 
+<llm-exclude>
+
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{263,294} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{237,264} -->
 
 :::
+
+</llm-exclude>

--- a/docs/task/rollback.md
+++ b/docs/task/rollback.md
@@ -38,3 +38,7 @@ Besides task failures, `rollback` also runs when a run is interrupted with `Ctrl
 ### _DefaultRenderer_
 
 When rollback is activated the default renderer will change the spinner color to bright red, if the rollback successfully concludes then it will be a redback arrow, else it would be like a normal error where it will show the error from the rollback action itself.
+
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers cannot recolor a spinner, so they log a `ROLLBACK` entry carrying the rollback message instead.

--- a/docs/task/skip.md
+++ b/docs/task/skip.md
@@ -10,7 +10,7 @@ category:
 
 # {{ $frontmatter.title }}
 
-Conditional skip is another way of enabling a _Task_ depending on the given context. But the main difference between `enable` and `skip` is `skip` will always render the given task. When the execution time comes, and it turns out that it should be skipped, it will render or mark it as skipped.
+Conditional skip is a way of skipping a _Task_ depending on the given context. But the main difference between `enable` and `skip` is `skip` will always render the given task. When the execution time comes, and it turns out that it should be skipped, it will render or mark it as skipped.
 
 <!-- more -->
 
@@ -44,8 +44,12 @@ Skip call can either have or not have a message, therefore it is optional. Havin
 
 The default renderer has options where you can change how the skip messages are displayed.
 
+<llm-exclude>
+
 ::: details
 
-<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{168,221} -->
+<!-- @include: ../api/listr2/interfaces/ListrDefaultRendererOptions.md{152,199} -->
 
 :::
+
+</llm-exclude>

--- a/docs/task/skip.md
+++ b/docs/task/skip.md
@@ -53,3 +53,7 @@ The default renderer has options where you can change how the skip messages are 
 :::
 
 </llm-exclude>
+
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers log a `SKIPPED` entry with the skip reason when a task is skipped; the display options above are specific to the _DefaultRenderer_.

--- a/docs/task/subtasks.md
+++ b/docs/task/subtasks.md
@@ -55,3 +55,13 @@ You can access the parent task class from subtasks by passing the function signa
 <<< @../../examples/docs/task/subtasks/access-parent-task.ts{9,15}
 
 :::
+
+## Renderer
+
+### _DefaultRenderer_
+
+Subtasks are rendered as an indented block under the parent task and can be collapsed once finished through the `collapseSubtasks` renderer option.
+
+### _SimpleRenderer_ & _VerboseRenderer_
+
+The non-TTY renderers have no nesting area to collapse; each subtask's state changes are logged inline as they happen, in the order they run.

--- a/docs/task/task-options.md
+++ b/docs/task/task-options.md
@@ -26,7 +26,7 @@ Naturally, subtasks options are a subset of the general options, since some opti
 
 ## Per _Task_
 
-Some properties of the task options even propagate to the per-task setting, these are pretty limited in form of configuration but should be just enough for you to not wrap everything in subtasks to change behavior.
+Some of the task options propagate down to the per-task level. These per-task options are limited in scope, but usually enough to change a single task's behavior without wrapping it in a subtask.
 
 ## Adding Task Options
 

--- a/docs/task/title.md
+++ b/docs/task/title.md
@@ -18,7 +18,7 @@ _Task_ can have a title to stand out from the crowd and give the user visual que
 
 The title of the _Task_ can be initiated while creating the task itself and, can be directly manipulated through the injected `task` object during runtime.
 
-This allows the user to change the title depending on the progress that has been made throughout the task or just inform the user that the task is finished, so looking from a grammar perspective it will all look right.
+This allows the user to change the title depending on the progress made throughout the task, or simply to inform the user that the task is finished.
 
 <<< @../../examples/docs/task/title/task-title.ts{5,9,13}
 

--- a/examples/docs/listr/context/as-option.ts
+++ b/examples/docs/listr/context/as-option.ts
@@ -5,10 +5,8 @@ interface Ctx {}
 const ctx: Ctx = {}
 
 const tasks = new Listr<Ctx>(
-  [
-    /* tasks */
-  ],
-  { ctx }
+  [/* tasks */],
+  { ctx } // [!code highlight]
 )
 
 await tasks.run()

--- a/examples/docs/listr/context/at-runtime.ts
+++ b/examples/docs/listr/context/at-runtime.ts
@@ -4,8 +4,6 @@ interface Ctx {}
 
 const ctx: Ctx = {}
 
-const tasks = new Listr<Ctx>([
-  /* tasks */
-])
+const tasks = new Listr<Ctx>([/* tasks */])
 
-await tasks.run({ ctx })
+await tasks.run({ ctx }) // [!code highlight]


### PR DESCRIPTION
Brings the documentation site back in line with the current v11 codebase, hardens the fragile code-snippet anchors, fills coverage gaps, and finishes the generated-API exclusion from the LLM output. Structure is preserved (`repository/`, `listr/`, `task/`, `renderer/`, `migration/`).

## What changed

- **Remove resolved help-wanted section** — the "Updating Renderer" contribution ask described work that shipped in v11 (partial/differential `log-update` v8 rendering), so it was sending contributors after a solved problem.
- **Fix & harden snippet anchors** — corrected 8 broken/drifted anchors (dead `@[code]` syntax, dash-form include ranges that silently dropped, highlight lines that no longer matched the source) and made the drift-prone context examples robust with comment-based `// [!code highlight]` markers instead of absolute line numbers.
- **Correct factual drift vs v11** — `ListrError` no longer carries `ctx`; `Listr.errors` is nullable and the property is `errors` (plural); `SimpleRenderer` is the non-TTY fallback default; `ListrTaskRetry` exposes `error`; examples run via the `@listr2/examples` workspace, not `ts-node`.
- **Clarify prose** — rewrote confusing/broken sentences across the task, renderer, and repository pages.
- **Fill coverage gaps** — documented the partial rendering behavior, `task.report()`, the retry pause countdown, `ListrLogger` prefix/suffix fields, the `ProcessOutput` write API, and the per-task renderer events.
- **Document Manager usage** — added a real Usage section (factory, `newListr`, `add`/`runAll`, one-off `run`, shared `ctx`/`errors`).
- **Document non-TTY renderer behavior** — the per-feature `## Renderer` sections now cover `SimpleRenderer`/`VerboseRenderer` (output, rollback, skip, retry, errors, subtasks), not just `DefaultRenderer`.
- **Structure** — moved `Interruption` after `Manager`; excluded the build output directory from the generated sidebar (removes a stray "Dist" nav section).
- **Changelog** — replaced the embedded generated `CHANGELOG` dump with links to each published package's changelog on GitHub.

## LLM output (the "ignore the generated API" task)

The generated typedoc API reference was leaking into `llms.txt`/`llms-full.txt` through `<!-- @include -->` transclusions, which `ignoreFiles: ['api/**']` cannot reach. Each `::: details` API block is now wrapped in `<llm-exclude>` so the generated interface dumps stay out of the LLM output while remaining fully visible in the human docs. The runnable examples are intentionally kept in the LLM output.

## Notes

- **`lastUpdated` correctness** — VitePress derives each page's timestamp from its most recent git commit, which is per-file by design. The docs build ran on GitLab's default shallow clone, which collapses every page to the same date; `GIT_DEPTH: 0` on the docs job fixes it. Only the docs job is touched.
- **Merge strategy** — this branch carries several meaningful, separated commits. Please merge/rebase rather than squash so the history survives.
- All `docs:`/`ci:` commits — no release bump.

## Verification

- `pnpm run docs:build` succeeds (typedoc + vitepress).
- Example edits stay lint-clean; the `[!code highlight]` comments moved with the code under prettier — proving the anchors are drift-proof.
- `llms-full.txt`: 0 generated interface dumps, examples retained; human `renderer/default.html` still shows the full API tables; no `<llm-exclude>` tag leaks into HTML; the sidebar has no "Dist" section.
